### PR TITLE
Bugfix: localnet mint seeded tokens

### DIFF
--- a/scripts/mintLocalNetTokens.js
+++ b/scripts/mintLocalNetTokens.js
@@ -3,30 +3,38 @@ const SolWeb3 = require('@solana/web3.js')
 const fs = require('fs')
 
 const { Token, TOKEN_PROGRAM_ID } = SPLToken
-const {
-  Account,
-  Connection,
-} = SolWeb3
+const { Account, Connection } = SolWeb3
 
 ;(async () => {
   const connection = new Connection('http://127.0.0.1:8899')
-  const keyPairFilePath = process.argv[2];
-  const walletAddress = process.argv[3];
-  let payer;
+  const keyPairFilePath = process.argv[2]
+  const walletAddress = process.argv[3]
+  let payer
   if (!keyPairFilePath) {
-    throw new Error('Missing keypair file argument');
+    throw new Error('Missing keypair file argument')
   }
-  const keyBuffer = fs.readFileSync(keyPairFilePath);
-  payer = new Account(JSON.parse(keyBuffer));
+  const keyBuffer = fs.readFileSync(keyPairFilePath)
+  payer = new Account(JSON.parse(keyBuffer))
 
-  const localSPLData = JSON.parse(fs.readFileSync('./src/hooks/localnetData.json'));
+  const localSPLData = JSON.parse(
+    fs.readFileSync('./src/hooks/localnetData.json')
+  )
 
   // For each SPL Token created, create a new account owned by payer and mint 1,000 tokens
   localSPLData.forEach(async (splData, index) => {
-    const token = new Token(connection, splData.mintAddress, TOKEN_PROGRAM_ID, payer);
-    const newTokenAccount = await token.createAccount(walletAddress || payer);
+    const token = new Token(
+      connection,
+      splData.mintAddress,
+      TOKEN_PROGRAM_ID,
+      payer
+    )
+    const newTokenAccount = await token.createAccount(
+      walletAddress || payer.publicKey
+    )
     // The tokens created by the seedLocalNet have 8 decimals
-    token.mintTo(newTokenAccount, payer, [], 1000 * 10**8);
-    console.log(`** created account ${newTokenAccount} with 1,000 ${splData.mintAddress} tokens\n`);
-  });
-})();
+    token.mintTo(newTokenAccount, payer, [], 1000 * 10 ** 8)
+    console.log(
+      `** created account ${newTokenAccount} with 1,000 ${splData.mintAddress} tokens\n`
+    )
+  })
+})()


### PR DESCRIPTION
So I fixed the problem I was having with minting the seeded localnet SPLs -- the issue is that I wasn't providing a wallet address to the script, and when it was trying to fall back to the payer instead, it was actually passing the whole account object into `token.createAccount`. I looked into the token source code and saw that it only takes a public key, not a full account, so I fixed this by passing the public key instead of the full account.

Also my prettier formatted the file on save... sorry about the extra edits.

![Screen Shot 2021-02-25 at 10 48 42 AM](https://user-images.githubusercontent.com/9023427/109178611-08e4bb00-7757-11eb-8679-5af532d0e59d.png)
