### PR TITLE
Add switch for multiple strikes in initialize page

### DIFF
--- a/src/components/pages/InitializeMarket.js
+++ b/src/components/pages/InitializeMarket.js
@@ -1,7 +1,15 @@
 import React, { useState } from 'react'
 import moment from 'moment'
 
-import { Box, Paper, Button, Chip, TextField } from '@material-ui/core'
+import {
+  Box,
+  Paper,
+  Button,
+  Chip,
+  TextField,
+  Switch,
+  FormControlLabel,
+} from '@material-ui/core'
 import Done from '@material-ui/icons/Done'
 import Page from './Page'
 import SelectAsset from '../SelectAsset'
@@ -26,6 +34,7 @@ const InitializeMarket = () => {
   const { connect, connected } = useWallet()
   const { getMyMarkets, getMarket, initializeMarkets } = useOptionsMarkets()
 
+  const [multiple, setMultiple] = useState(false)
   const [basePrice, setBasePrice] = useState(0)
   const [date, setDate] = useState(next3Months[0])
   const [uAsset, setUAsset] = useState()
@@ -40,6 +49,7 @@ const InitializeMarket = () => {
   const parsedBasePrice = parseInt(basePrice)
   let strikePrices = []
   if (
+    multiple &&
     (parsedBasePrice || marketPrice) &&
     priceInterval &&
     !isNaN(priceInterval)
@@ -48,6 +58,8 @@ const InitializeMarket = () => {
       parsedBasePrice || marketPrice,
       priceInterval
     )
+  } else if (parsedBasePrice || marketPrice) {
+    strikePrices = [parsedBasePrice || marketPrice]
   }
 
   const assetsSelected = uAsset && qAsset
@@ -180,16 +192,40 @@ const InitializeMarket = () => {
                     variant="filled"
                     onChange={(e) => setBasePrice(e.target.value)}
                     helperText={
-                      isNaN(priceInterval) ? 'Must be a number' : null
+                      isNaN(parsedBasePrice) ? 'Must be a number' : null
                     }
                   />
                 </Box>
-                <TextField
-                  label="Price Interval"
-                  variant="filled"
-                  onChange={(e) => setPriceInterval(parseFloat(e.target.value))}
-                  helperText={isNaN(priceInterval) ? 'Must be a number' : null}
+              </Box>
+            </Box>
+
+            <Box display="flex" alignItems="center" borderBottom={darkBorder}>
+              <Box width={'50%'} p={2}>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={multiple}
+                      onChange={() => setMultiple(!multiple)}
+                      name="multiple"
+                      color="secondary"
+                    />
+                  }
+                  label="Multi Strikes"
                 />
+              </Box>
+              <Box width={'50%'} p={2}>
+                {multiple ? (
+                  <TextField
+                    label="Price Interval"
+                    variant="filled"
+                    onChange={(e) =>
+                      setPriceInterval(parseFloat(e.target.value))
+                    }
+                    helperText={
+                      isNaN(priceInterval) ? 'Must be a number' : null
+                    }
+                  />
+                ) : null}
               </Box>
             </Box>
 


### PR DESCRIPTION
Hmm this was less work than I expected!

Single (this is the default now):
![Screen Shot 2021-02-25 at 11 37 25 AM](https://user-images.githubusercontent.com/9023427/109185508-15204680-775e-11eb-9644-f268c6a125a4.png)
![Screen Shot 2021-02-25 at 11 37 09 AM](https://user-images.githubusercontent.com/9023427/109185537-1a7d9100-775e-11eb-9a0e-99621205cefb.png)

Multiple:
![Screen Shot 2021-02-25 at 11 37 28 AM](https://user-images.githubusercontent.com/9023427/109185582-25d0bc80-775e-11eb-8afb-de7163605473.png)
![Screen Shot 2021-02-25 at 11 37 15 AM](https://user-images.githubusercontent.com/9023427/109185593-28331680-775e-11eb-8791-d152899b126e.png)
