### PR TITLE
Hide networks without a program id

### DIFF
--- a/src/components/NetworkMenu.js
+++ b/src/components/NetworkMenu.js
@@ -11,13 +11,7 @@ import useConnection from '../hooks/useConnection'
 import theme from '../utils/theme'
 
 const NetworkMenu = () => {
-  const {
-    networks,
-    connection,
-    endpoint,
-    setEndpoint,
-    setProgramId,
-  } = useConnection()
+  const { networks, endpoint, setEndpoint } = useConnection()
 
   const [open, setOpen] = useState(false)
   const anchorRef = React.useRef(null)
@@ -74,20 +68,22 @@ const NetworkMenu = () => {
               id="menu-list-grow"
               onKeyDown={handleListKeyDown}
             >
-              {networks.map((item) => (
-                <MenuItem
-                  onClick={(event) => {
-                    setEndpoint(item)
-                    handleClose(event)
-                  }}
-                  key={item.url}
-                >
-                  <Box>
-                    <Box>{item.name}</Box>
-                    <Box fontSize={10}>{item.url}</Box>
-                  </Box>
-                </MenuItem>
-              ))}
+              {networks
+                .filter((n) => n.programId !== undefined)
+                .map((item) => (
+                  <MenuItem
+                    onClick={(event) => {
+                      setEndpoint(item)
+                      handleClose(event)
+                    }}
+                    key={item.url}
+                  >
+                    <Box>
+                      <Box>{item.name}</Box>
+                      <Box fontSize={10}>{item.url}</Box>
+                    </Box>
+                  </MenuItem>
+                ))}
             </MenuList>
           </ClickAwayListener>
         </Card>

--- a/src/context/ConnectionContext.js
+++ b/src/context/ConnectionContext.js
@@ -27,7 +27,10 @@ const networks = [
   },
 ]
 
-const DEFAULT_NETWORK = networks[0]
+// Default to first network that has a defined program id
+const DEFAULT_NETWORK = networks.find(
+  (network) => network.programId !== undefined,
+)
 
 const ConnectionContext = createContext({})
 


### PR DESCRIPTION
Also default to the first network that has a program id.

When a network without a program id is selected, we can''t load the markets or use the app anyway. This will also let us hide localnet on the deployed versions by removing the localnet program id from the environment variables