### PR TITLE
Fix contract size display upon initializing market

### DIFF
--- a/src/components/pages/InitializeMarket.js
+++ b/src/components/pages/InitializeMarket.js
@@ -76,7 +76,7 @@ const InitializeMarket = () => {
 
     try {
       setLoading(true)
-      const results = await initializeMarkets({
+      await initializeMarkets({
         size: sizeAsU64,
         strikePrices,
         uAssetSymbol: uAsset.tokenSymbol,
@@ -84,8 +84,8 @@ const InitializeMarket = () => {
         uAssetMint: uAsset.mintAddress,
         qAssetMint: qAsset.mintAddress,
         expiration: date.unix(),
+        decimals: uAsset.decimals
       })
-      console.log(results)
       setLoading(false)
     } catch (err) {
       setLoading(false)

--- a/src/hooks/useOptionsMarkets.js
+++ b/src/hooks/useOptionsMarkets.js
@@ -146,6 +146,7 @@ const useOptionsMarkets = () => {
     uAssetMint,
     qAssetMint,
     expiration,
+    decimals
   }) => {
     const results = await Promise.all(
       strikePrices.map(async (strikePrice) => {
@@ -213,8 +214,11 @@ const useOptionsMarkets = () => {
 
     const newMarkets = {}
     results.forEach((market) => {
-      newMarkets[market.key] = market
-      return market
+      const m = market
+      m.size = `${market.size * 10 ** -decimals}`
+      m.strikePrice = `${market.strikePrice}` 
+      newMarkets[market.key] = m
+      return m
     })
     setMarkets({ ...markets, ...newMarkets })
 


### PR DESCRIPTION
Fixes duplicate displays of markets after initializing and not reloading the page before proceeding to markets