### PR TITLE
Remove gradient from markets page header

### DIFF
--- a/src/components/pages/Markets.js
+++ b/src/components/pages/Markets.js
@@ -253,14 +253,11 @@ const Markets = () => {
         minHeight="100%"
       >
         <Box
-          py={0}
+          py={[0, 0, 2]}
           display="flex"
           flexDirection={['column', 'column', 'row']}
           alignItems="center"
           justifyContent="space-between"
-          style={{
-            background: `${theme.gradients.secondary}`,
-          }}
         >
           <Box px={0} py={0} width={['100%', '100%', '300px']}>
             <Select


### PR DESCRIPTION

<img width="357" alt="Screen Shot 2021-03-01 at 11 28 36 AM" src="https://user-images.githubusercontent.com/9023427/109534820-bde5e300-7a89-11eb-84e5-ecb72aa2f80a.png">

<img width="1438" alt="Screen Shot 2021-03-01 at 11 28 10 AM" src="https://user-images.githubusercontent.com/9023427/109534812-bb838900-7a89-11eb-96f0-3e0bfab8c40c.png">
