### PR TITLE
Update notification colors to make text more visible

### DIFF
--- a/src/components/Notifications.js
+++ b/src/components/Notifications.js
@@ -34,7 +34,7 @@ const SimpleSnackbar = ({
       borderRadius={3}
       display="flex"
       justifyContent="space-between"
-      color={theme.palette[severity].contrastText}
+      color={theme.palette.primary.light}
       style={{
         background: theme.gradients[severity],
       }}

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -4,10 +4,10 @@ const theme = createMuiTheme({
   gradients: {
     secondary: 'linear-gradient(90deg, #24001A 0%, #790068 50%, #D18641 100%)',
     secondaryPrimary: 'linear-gradient(90deg, #DD3E76 -0.83%, #1D4DC9 100%)',
-    warning: 'linear-gradient(90deg, #F9C164 0.22%, #DC3E78 99.68%)',
-    error: 'linear-gradient(90deg, #F9C164 0.22%, #DC3E78 99.68%)',
-    success: 'linear-gradient(-90deg, #51F39C 0.41%, #1D4DC9 117.22%)',
-    info: 'linear-gradient(90deg, #DC3E78 0.62%, #1D4DC9 89.59%)',
+    warning: 'linear-gradient(90deg, #DC3E78 0%, #FA8965 100%)',
+    error: 'linear-gradient(90deg, #790068 0%, #DD3E76 100%)',
+    success: 'linear-gradient(90deg, #14758A 0%, #28C972 100%)',
+    info: 'linear-gradient(90deg, #686775 0%, #9C9CB6 100%)',
   },
   glow: '0 0 0px #11FFCC, 0 0 20px #0055CC, 0 0 50px #001199',
   typography: {


### PR DESCRIPTION
I've been feeling like the notifications are a little hard to read, there are too many colors all at once, so I tried to adjust them to be a little less vibrant and make the text easier to read.

All examples, in order: Success, Info, Error, Warning
![Screen Shot 2021-03-01 at 2 41 05 PM](https://user-images.githubusercontent.com/9023427/109549942-a3693500-7a9c-11eb-9887-936bf1b16997.png)

Examples from actual test transactions I did:
![Screen Shot 2021-03-01 at 2 43 18 PM](https://user-images.githubusercontent.com/9023427/109549978-b11eba80-7a9c-11eb-873d-b860dae7eca2.png)

![Screen Shot 2021-03-01 at 2 43 44 PM](https://user-images.githubusercontent.com/9023427/109549990-b54ad800-7a9c-11eb-9c6b-457a2d0650e4.png)
