### PR TITLE
Store uAsset and qAsset in context

### DIFF
--- a/src/components/SelectAsset.js
+++ b/src/components/SelectAsset.js
@@ -17,12 +17,12 @@ import useAssetList from '../hooks/useAssetList'
 
 const SelectAsset = ({ label, selectedAsset, onSelectAsset }) => {
   const theme = useTheme()
-  const assetList = useAssetList()
+  const { supportedAssets } = useAssetList()
 
   const [open, setOpen] = useState(false)
   const [filterInput, setFilterInput] = useState('')
 
-  const filteredAssetList = assetList.filter((item) => {
+  const filteredAssetList = supportedAssets.filter((item) => {
     const match = filterInput.toLowerCase()
     const shouldAppear =
       item.tokenName.toLowerCase().match(match) ||
@@ -66,22 +66,22 @@ const SelectAsset = ({ label, selectedAsset, onSelectAsset }) => {
             </Box>
             <Box my={3} height="300px" overflow="auto">
               {filteredAssetList.map((asset) => (
-                  <ListItem
-                    button
-                    onClick={() => {
-                      setOpen(false)
-                      onSelectAsset(asset)
-                    }}
-                    key={asset.mintAddress}
-                  >
-                    <ListItemAvatar>
-                      <Avatar src={asset.icon} />
-                    </ListItemAvatar>
-                    <ListItemText
-                      primary={`${asset.tokenName} (${asset.tokenSymbol})`}
-                    />
-                  </ListItem>
-                ))}
+                <ListItem
+                  button
+                  onClick={() => {
+                    setOpen(false)
+                    onSelectAsset(asset)
+                  }}
+                  key={asset.mintAddress}
+                >
+                  <ListItemAvatar>
+                    <Avatar src={asset.icon} />
+                  </ListItemAvatar>
+                  <ListItemText
+                    primary={`${asset.tokenName} (${asset.tokenSymbol})`}
+                  />
+                </ListItem>
+              ))}
             </Box>
           </Box>
         </Box>

--- a/src/components/pages/InitializeMarket.js
+++ b/src/components/pages/InitializeMarket.js
@@ -21,6 +21,7 @@ import useOptionsMarkets from '../../hooks/useOptionsMarkets'
 import useSerumMarketInfo from '../../hooks/useSerumMarketInfo'
 import { generateStrikePrices } from '../../utils/generateStrikePrices'
 import { getNext3Months } from '../../utils/dates'
+import useAssetList from '../../hooks/useAssetList'
 
 const darkBorder = `1px solid ${theme.palette.background.main}`
 
@@ -34,8 +35,7 @@ const InitializeMarket = () => {
   const [multiple, setMultiple] = useState(false)
   const [basePrice, setBasePrice] = useState(0)
   const [date, setDate] = useState(next3Months[0])
-  const [uAsset, setUAsset] = useState()
-  const [qAsset, setQAsset] = useState()
+  const { uAsset, qAsset, setUAsset, setQAsset } = useAssetList()
   const [size, setSize] = useState(0)
   const [priceInterval, setPriceInterval] = useState(0)
   const { marketPrice } = useSerumMarketInfo({
@@ -84,7 +84,7 @@ const InitializeMarket = () => {
         uAssetMint: uAsset.mintAddress,
         qAssetMint: qAsset.mintAddress,
         expiration: date.unix(),
-        decimals: uAsset.decimals
+        decimals: uAsset.decimals,
       })
       setLoading(false)
     } catch (err) {

--- a/src/components/pages/Markets/Markets.js
+++ b/src/components/pages/Markets/Markets.js
@@ -12,30 +12,10 @@ import Select from '../../Select'
 import SelectAsset from '../../SelectAsset'
 import { getNext3Months } from '../../../utils/dates'
 
-import useConnection from '../../../hooks/useConnection'
 import useAssetList from '../../../hooks/useAssetList'
 import useOptionChain from '../../../hooks/useOptionChain'
 
-import CallPutRow from './CallPutRow';
-
-const defaultAssetPairsByNetworkName = {
-  Mainnet: {
-    uAssetSymbol: 'SOL',
-    qAssetSymbol: 'USDC',
-  },
-  Devnet: {
-    uAssetSymbol: 'PSYA',
-    qAssetSymbol: 'USDCT', // TODO add this
-  },
-  Testnet: {
-    uAssetSymbol: 'SOL',
-    qAssetSymbol: 'ABC',
-  },
-  localhost: {
-    uAssetSymbol: 'SOL',
-    qAssetSymbol: 'USDC',
-  },
-}
+import CallPutRow from './CallPutRow'
 
 const TCell = withStyles({
   root: {
@@ -76,48 +56,18 @@ const next3Months = getNext3Months()
 const emptyRows = Array(9).fill(rowTemplate)
 
 const Markets = () => {
-  const { endpoint } = useConnection()
-
-  const supportedAssets = useAssetList()
+  const { uAsset, qAsset, setUAsset, setQAsset } = useAssetList()
   const [date, setDate] = useState(next3Months[0])
-  const [uAsset, setUAsset] = useState()
-  const [qAsset, setQAsset] = useState()
   const [rows, setRows] = useState(emptyRows)
-
-
-  useEffect(() => {
-    if (supportedAssets && supportedAssets.length > 0) {
-      const defaultAssetPair =
-        defaultAssetPairsByNetworkName[endpoint.name] || {}
-      let defaultUAsset
-      let defaultQAsset
-      supportedAssets.forEach((asset) => {
-        if (asset.tokenSymbol === defaultAssetPair.uAssetSymbol) {
-          defaultUAsset = asset
-        }
-        if (asset.tokenSymbol === defaultAssetPair.qAssetSymbol) {
-          defaultQAsset = asset
-        }
-      })
-      if (defaultUAsset && defaultQAsset) {
-        setUAsset(defaultUAsset)
-        setQAsset(defaultQAsset)
-      }
-    }
-  }, [endpoint, supportedAssets])
-
   const { chain } = useOptionChain(date, uAsset, qAsset)
 
   useEffect(() => {
     let newRows = chain.length ? chain : emptyRows
-
     if (newRows.length < 9) {
       newRows = [...newRows, ...emptyRows.slice(newRows.length)]
     }
-
     setRows(newRows)
   }, [chain])
-
 
   return (
     <Page>
@@ -234,7 +184,15 @@ const Markets = () => {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {rows.map((row, i) => (<CallPutRow key={i} row={row} uAsset={uAsset} qAsset={qAsset} date={date}/>))}
+                {rows.map((row, i) => (
+                  <CallPutRow
+                    key={i}
+                    row={row}
+                    uAsset={uAsset}
+                    qAsset={qAsset}
+                    date={date}
+                  />
+                ))}
               </TableBody>
             </Table>
           </TableContainer>

--- a/src/components/pages/Mint.js
+++ b/src/components/pages/Mint.js
@@ -18,6 +18,7 @@ import Page from './Page'
 import Select from '../Select'
 
 import { getNext3Months } from '../../utils/dates'
+import useAssetList from '../../hooks/useAssetList'
 
 const darkBorder = `1px solid ${theme.palette.background.main}`
 
@@ -37,8 +38,7 @@ const Mint = () => {
   const dates = next3Months
 
   const [date, setDate] = useState(dates[0])
-  const [uAsset, setUAsset] = useState()
-  const [qAsset, setQAsset] = useState()
+  const { uAsset, qAsset, setUAsset, setQAsset } = useAssetList()
   const [size, setSize] = useState(100)
   const [price, setPrice] = useState('')
   const [uAssetAccount, setUAssetAccount] = useState('')

--- a/src/context/store.js
+++ b/src/context/store.js
@@ -7,7 +7,7 @@ import { OwnedTokenAccountsProvider } from './OwnedTokenAccounts'
 import { WalletProvider } from './WalletContext'
 import { NotificationsProvider } from './NotificationsContext'
 import { OptionsMarketsProvider } from './OptionsMarketsContext'
-import { SupportedAssetProvider } from './SupportedAssetContext'
+import { AssetListProvider } from './AssetListContext'
 import theme from '../utils/theme'
 
 const _providers = [
@@ -15,7 +15,7 @@ const _providers = [
   <ThemeProvider theme={theme} children={<div />} />,
   <NotificationsProvider />,
   <ConnectionProvider />,
-  <SupportedAssetProvider />,
+  <AssetListProvider />,
   <WalletProvider />,
   <OwnedTokenAccountsProvider />,
   <OptionsMarketsProvider />,

--- a/src/hooks/useAssetList.js
+++ b/src/hooks/useAssetList.js
@@ -1,9 +1,6 @@
-import { useContext } from 'react';
-import { SupportedAssetContext } from '../context/SupportedAssetContext';
+import { useContext } from 'react'
+import { AssetListContext } from '../context/AssetListContext'
 
-const useAssetList = () => {
-  const supportedAssets = useContext(SupportedAssetContext);
-  return supportedAssets;
-}
+const useAssetList = () => useContext(AssetListContext)
 
 export default useAssetList

--- a/src/hooks/useOptionsMarkets.js
+++ b/src/hooks/useOptionsMarkets.js
@@ -43,13 +43,15 @@ const useOptionsMarkets = () => {
   const { wallet, pubKey } = useWallet()
   const { connection, endpoint } = useConnection()
   const { markets, setMarkets } = useContext(OptionsMarketsContext)
-  const assetList = useAssetList()
+  const { supportedAssets } = useAssetList()
 
   const fetchMarketData = useCallback(async () => {
     try {
       if (!(connection instanceof Connection)) return
       if (!endpoint.programId) return
-      const assets = assetList.map((asset) => new PublicKey(asset.mintAddress))
+      const assets = supportedAssets.map(
+        (asset) => new PublicKey(asset.mintAddress),
+      )
       const res = await Market.getAllMarketsBySplSupport(
         connection,
         new PublicKey(endpoint.programId),
@@ -59,11 +61,11 @@ const useOptionsMarkets = () => {
       const newMarkets = {}
       res.forEach((market) => {
         const uAssetMint = market.marketData.underlyingAssetMintAddress
-        const uAsset = assetList.filter(
+        const uAsset = supportedAssets.filter(
           (asset) => asset.mintAddress === uAssetMint.toString(),
         )[0]
         const qAssetMint = market.marketData.quoteAssetMintAddress
-        const qAsset = assetList.filter(
+        const qAsset = supportedAssets.filter(
           (asset) => asset.mintAddress === qAssetMint.toString(),
         )[0]
 
@@ -104,7 +106,7 @@ const useOptionsMarkets = () => {
     } catch (err) {
       console.error(err)
     }
-  }, [connection, assetList, endpoint, setMarkets])
+  }, [connection, supportedAssets, endpoint, setMarkets])
 
   useEffect(() => {
     fetchMarketData()
@@ -146,7 +148,7 @@ const useOptionsMarkets = () => {
     uAssetMint,
     qAssetMint,
     expiration,
-    decimals
+    decimals,
   }) => {
     const results = await Promise.all(
       strikePrices.map(async (strikePrice) => {
@@ -216,7 +218,7 @@ const useOptionsMarkets = () => {
     results.forEach((market) => {
       const m = market
       m.size = `${market.size * 10 ** -decimals}`
-      m.strikePrice = `${market.strikePrice}` 
+      m.strikePrice = `${market.strikePrice}`
       newMarkets[market.key] = m
       return m
     })


### PR DESCRIPTION
This was a personal annoyance for me, it addresses the issue I opened:
https://github.com/mithraiclabs/solana-options-frontend/issues/137

Now when you select assets on one page, the selection persists on other pages as long as you don't refresh. To me this makes it a better experience to initialize, mint, check your positions, and mint more if you want to, without having to constantly select the assets. 

Demo: 
https://share.getcloudapp.com/L1uNyJ8Z
