### PR TITLE
Optimize Rerenders

### DIFF
--- a/src/components/pages/InitializeMarket.js
+++ b/src/components/pages/InitializeMarket.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 
 import {
   Box,
@@ -30,8 +30,7 @@ const next3Months = getNext3Months()
 const InitializeMarket = () => {
   const { pushNotification } = useNotifications()
   const { connect, connected } = useWallet()
-  const { getMarket, initializeMarkets } = useOptionsMarkets()
-
+  const { getMarket, fetchMarketData, initializeMarkets } = useOptionsMarkets()
   const [multiple, setMultiple] = useState(false)
   const [basePrice, setBasePrice] = useState(0)
   const [date, setDate] = useState(next3Months[0])
@@ -43,6 +42,10 @@ const InitializeMarket = () => {
     qAssetMint: qAsset?.mintAddress,
   })
   const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    fetchMarketData()
+  }, [fetchMarketData])
 
   const parsedBasePrice = parseFloat(
     basePrice && basePrice.replace(/^\./, '0.'),

--- a/src/components/pages/Markets/Markets.js
+++ b/src/components/pages/Markets/Markets.js
@@ -14,6 +14,7 @@ import { getNext3Months } from '../../../utils/dates'
 
 import useAssetList from '../../../hooks/useAssetList'
 import useOptionChain from '../../../hooks/useOptionChain'
+import useOptionsMarkets from '../../../hooks/useOptionsMarkets'
 
 import CallPutRow from './CallPutRow'
 
@@ -54,21 +55,22 @@ const rowTemplate = {
 }
 
 const next3Months = getNext3Months()
-const emptyRows = Array(9).fill(rowTemplate)
 
 const Markets = () => {
   const { uAsset, qAsset, setUAsset, setQAsset } = useAssetList()
   const [date, setDate] = useState(next3Months[0])
-  const [rows, setRows] = useState(emptyRows)
-  const { chain } = useOptionChain(date, uAsset, qAsset)
+  const { chain, fetchOptionsChain } = useOptionChain()
+  const { fetchMarketData } = useOptionsMarkets()
+
+  const rows = [...chain, ...Array(9 - chain.length).fill(rowTemplate)]
 
   useEffect(() => {
-    let newRows = chain.length ? chain : emptyRows
-    if (newRows.length < 9) {
-      newRows = [...newRows, ...emptyRows.slice(newRows.length)]
-    }
-    setRows(newRows)
-  }, [chain])
+    fetchMarketData()
+  }, [fetchMarketData])
+
+  useEffect(() => {
+    fetchOptionsChain(date.unix())
+  }, [fetchOptionsChain, date])
 
   return (
     <Page>

--- a/src/components/pages/Mint.js
+++ b/src/components/pages/Mint.js
@@ -32,6 +32,7 @@ const Mint = () => {
     getStrikePrices,
     getSizes,
     createAccountsAndMint,
+    fetchMarketData,
   } = useOptionsMarkets()
   const { ownedTokenAccounts } = useOwnedTokenAccounts()
 
@@ -71,6 +72,10 @@ const Mint = () => {
       (marketData && ownedTokenAccounts[marketData.optionMintAddress]) || [],
     [marketData, ownedTokenAccounts],
   )
+
+  useEffect(() => {
+    fetchMarketData()
+  }, [fetchMarketData])
 
   useEffect(() => {
     setUAssetAccount(ownedUAssetAccounts[0]?.pubKey || '')

--- a/src/components/pages/OpenPositions/OpenPositions.js
+++ b/src/components/pages/OpenPositions/OpenPositions.js
@@ -1,5 +1,5 @@
 import { Box, Paper } from '@material-ui/core'
-import React from 'react'
+import React, { useEffect } from 'react'
 import Table from '@material-ui/core/Table'
 import TableBody from '@material-ui/core/TableBody'
 import TableCell from '@material-ui/core/TableCell'
@@ -29,7 +29,11 @@ const OpenPositions = () => {
   const [page] = React.useState(0)
   const [rowsPerPage] = React.useState(10)
   const positions = useOpenPositions()
-  const { markets } = useOptionsMarkets()
+  const { markets, fetchMarketData } = useOptionsMarkets()
+
+  useEffect(() => {
+    fetchMarketData()
+  }, [fetchMarketData])
 
   const positionRows = Object.keys(positions).map((key) => ({
     accounts: positions[key],
@@ -67,7 +71,7 @@ const OpenPositions = () => {
             <Table stickyHeader aria-label="sticky table">
               <TableHead>
                 <TableRow>
-                  <TableCell width="5%"/>
+                  <TableCell width="5%" />
                   <TableCell width="15%">Asset Pair</TableCell>
                   <TableCell width="15%">Strike</TableCell>
                   <TableCell width="15%">Market Price</TableCell>

--- a/src/context/OptionsChainContext.js
+++ b/src/context/OptionsChainContext.js
@@ -1,0 +1,25 @@
+import React, { useState, createContext } from 'react'
+import PropTypes from 'prop-types'
+
+const OptionsChainContext = createContext()
+
+const OptionsChainProvider = ({ children }) => {
+  const [chain, setChain] = useState([])
+  const [loading, setLoading] = useState(false)
+
+  return (
+    <OptionsChainContext.Provider value={{ chain, setChain, loading, setLoading }}>
+      {children}
+    </OptionsChainContext.Provider>
+  )
+}
+
+OptionsChainProvider.propTypes = {
+  children: PropTypes.node,
+}
+
+OptionsChainProvider.defaultProps = {
+  children: null,
+}
+
+export { OptionsChainContext, OptionsChainProvider }

--- a/src/context/store.js
+++ b/src/context/store.js
@@ -7,6 +7,7 @@ import { OwnedTokenAccountsProvider } from './OwnedTokenAccounts'
 import { WalletProvider } from './WalletContext'
 import { NotificationsProvider } from './NotificationsContext'
 import { OptionsMarketsProvider } from './OptionsMarketsContext'
+import { OptionsChainProvider } from './OptionsChainContext'
 import { AssetListProvider } from './AssetListContext'
 import theme from '../utils/theme'
 
@@ -19,6 +20,7 @@ const _providers = [
   <WalletProvider />,
   <OwnedTokenAccountsProvider />,
   <OptionsMarketsProvider />,
+  <OptionsChainProvider />
 ]
 
 // flatten context providers for simpler app component tree

--- a/src/hooks/useOptionChain.js
+++ b/src/hooks/useOptionChain.js
@@ -1,145 +1,152 @@
-import { useCallback, useEffect, useState } from "react"
-import BigNumber from "bignumber.js";
-import { PublicKey } from '@solana/web3.js'
+import { useCallback, useContext } from 'react'
+import BigNumber from 'bignumber.js'
+import { Connection, PublicKey } from '@solana/web3.js'
 import { SerumMarket } from '../utils/serum'
 import useConnection from './useConnection'
 import useOptionsMarkets from './useOptionsMarkets'
+import { OptionsChainContext } from '../context/OptionsChainContext'
+import useAssetList from './useAssetList'
 
 /**
- * 
- * @param {moment} expirationDate 
- * @param {*} uAsset 
- * @param {*} qAsset 
+ *
  */
-const useOptionChain = (expirationDate, uAsset, qAsset) => {
-  const { connection, dexProgramId } = useConnection();
+const useOptionChain = () => {
+  const { connection, dexProgramId } = useConnection()
   const { markets } = useOptionsMarkets()
-  const [chain, setChain] = useState([]);
+  const { uAsset, qAsset } = useAssetList()
+  const { chain, setChain } = useContext(OptionsChainContext)
 
-  const getOptionsChain = useCallback(async (date) => {
-    // const uaDecimals = new BN(10).pow(new BN(uAsset.decimals))
-    const callKeyPart = `${date}-${uAsset.tokenSymbol}-${qAsset.tokenSymbol}`
-    const putKeyPart = `${date}-${qAsset.tokenSymbol}-${uAsset.tokenSymbol}`
+  const fetchOptionsChain = useCallback(
+    async (dateTimestamp) => {
+      const numberOfMarkets = Object.keys(markets).length
+      if (
+        !(connection instanceof Connection) ||
+        !uAsset?.tokenSymbol ||
+        !qAsset?.tokenSymbol ||
+        !dateTimestamp ||
+        numberOfMarkets < 1
+      ) {
+        setChain([])
+        return
+      }
 
-    const calls = Object.keys(markets)
-      .filter((k) => k.match(callKeyPart))
-      .map((k) => markets[k])
-    const puts = Object.keys(markets)
-      .filter((k) => k.match(putKeyPart))
-      .map((k) => ({
-        ...markets[k],
-        reciprocalStrike: new BigNumber(1).div(new BigNumber(markets[k].strikePrice)).toString(10)
-      }))
+      const callKeyPart = `${dateTimestamp}-${uAsset.tokenSymbol}-${qAsset.tokenSymbol}`
+      const putKeyPart = `${dateTimestamp}-${qAsset.tokenSymbol}-${uAsset.tokenSymbol}`
 
-    // TODO - we might be able to convert amountPerContract and quoteAmountPerContract to strings and use them in the set to determine which calls/puts match up, instead of the strike price which could be something like 0.6666666667 while the inverse is 1.5
-    // So for example this array can be strings of '100/150' which would be the same in both cases
-    const strikes = Array.from(
-      new Set([
-        ...calls.map((m) => m.strikePrice),
-        // TODO reverse PUTs strikes back to calls...but see [comment](https://github.com/mithraiclabs/solana-options-frontend/issues/117#issuecomment-787984227)
-        //  for why this is such a difficult task. 
-        ...puts.map((m) => m.reciprocalStrike),
-      ]),
-    )
+      const calls = Object.keys(markets)
+        .filter((k) => k.match(callKeyPart))
+        .map((k) => markets[k])
+      const puts = Object.keys(markets)
+        .filter((k) => k.match(putKeyPart))
+        .map((k) => ({
+          ...markets[k],
+          reciprocalStrike: new BigNumber(1)
+            .div(new BigNumber(markets[k].strikePrice))
+            .toString(10),
+        }))
 
-    const template = {
-      key: '',
-      bid: '',
-      ask: '',
-      change: '',
-      volume: '',
-      openInterest: '',
-      size: '',
-      serumMarket: null,
-    }
+      // TODO - we might be able to convert amountPerContract and quoteAmountPerContract to strings and use them in the set to determine which calls/puts match up, instead of the strike price which could be something like 0.6666666667 while the inverse is 1.5
+      // So for example this array can be strings of '100/150' which would be the same in both cases
+      const strikes = Array.from(
+        new Set([
+          ...calls.map((m) => m.strikePrice),
+          // TODO reverse PUTs strikes back to calls...but see [comment](https://github.com/mithraiclabs/solana-options-frontend/issues/117#issuecomment-787984227)
+          //  for why this is such a difficult task.
+          ...puts.map((m) => m.reciprocalStrike),
+        ]),
+      )
 
-    const rows = []
+      const template = {
+        key: '',
+        bid: '',
+        ask: '',
+        change: '',
+        volume: '',
+        openInterest: '',
+        size: '',
+        serumMarket: null,
+      }
 
-    await Promise.all(
-      strikes.map(async (strike) => {
-        const sizes = new Set()
-  
-        const matchingCalls = calls.filter((c) => {
-          if (c.strikePrice === strike) {
-            sizes.add(c.size)
-            return true
-          }
-          return false
-        })
-  
-        const matchingPuts = puts.filter((p) => {
-          if (p.reciprocalStrike === strike) {
-            sizes.add(p.size)
-            return true
-          }
-          return false
-        })
-  
-        await Promise.all(
-          Array.from(sizes).map(async (size) => {
-            // const putSize = (new BN(strike).mul(new BN(size))).toString(10)
-            let call = matchingCalls.find((c) => c.size === size)
-            let put = matchingPuts.find((p) => p.size === size)
-            // TODO if Serum market exists, load the current Bid / Ask information for the premiums
-  
-            if (call) {
-              // check if there is a serum market
-              const serumMarket = await SerumMarket.findByAssets(
-                connection, 
-                new PublicKey(call.optionMintAddress), 
-                new PublicKey(call.qAssetMint), 
-                dexProgramId,
-              )
-              call = {
-                ...template,
-                ...call,
-                serumMarket,
-                initialized: true,
-              }
-            } else {
-              call = template
+      const rows = []
+
+      await Promise.all(
+        strikes.map(async (strike) => {
+          const sizes = new Set()
+
+          const matchingCalls = calls.filter((c) => {
+            if (c.strikePrice === strike) {
+              sizes.add(c.size)
+              return true
             }
-  
-            if (put) {
-              // check if there is a serum market
-              const serumMarket = await SerumMarket.findByAssets(
-                connection, 
-                new PublicKey(put.optionMintAddress), 
-                // NOTE the PUTs underlying asset is the quote asset for the serum market 
-                // because the strike prices are all denoted in it.
-                new PublicKey(put.uAssetMint), 
-                dexProgramId,
-              )
-              put = {
-                ...template,
-                ...put,
-                serumMarket,
-                initialized: true,
-              }
-            } else {
-              put = template
-            }
-  
-            rows.push({ strike, size, call, put })
+            return false
           })
-        )
-      })
-    )
 
-    rows.sort((a, b) => a.strike - b.strike)
-    setChain(rows);
-  }, [connection, dexProgramId, markets, uAsset, qAsset])
+          const matchingPuts = puts.filter((p) => {
+            if (p.reciprocalStrike === strike) {
+              sizes.add(p.size)
+              return true
+            }
+            return false
+          })
 
-  useEffect(() => {
-    if (!uAsset?.tokenSymbol || !qAsset?.tokenSymbol || !expirationDate) {
-      setChain([]);
-      return;
-    }
+          await Promise.all(
+            Array.from(sizes).map(async (size) => {
+              // const putSize = (new BN(strike).mul(new BN(size))).toString(10)
+              let call = matchingCalls.find((c) => c.size === size)
+              let put = matchingPuts.find((p) => p.size === size)
+              // TODO if Serum market exists, load the current Bid / Ask information for the premiums
 
-    getOptionsChain(expirationDate.unix());
-  }, [getOptionsChain, expirationDate, uAsset, qAsset]);
+              if (call) {
+                // check if there is a serum market
+                const serumMarket = await SerumMarket.findByAssets(
+                  connection,
+                  new PublicKey(call.optionMintAddress),
+                  new PublicKey(call.qAssetMint),
+                  dexProgramId,
+                )
+                call = {
+                  ...template,
+                  ...call,
+                  serumMarket,
+                  initialized: true,
+                }
+              } else {
+                call = template
+              }
 
-  return {chain};
+              if (put) {
+                // check if there is a serum market
+                const serumMarket = await SerumMarket.findByAssets(
+                  connection,
+                  new PublicKey(put.optionMintAddress),
+                  // NOTE the PUTs underlying asset is the quote asset for the serum market
+                  // because the strike prices are all denoted in it.
+                  new PublicKey(put.uAssetMint),
+                  dexProgramId,
+                )
+                put = {
+                  ...template,
+                  ...put,
+                  serumMarket,
+                  initialized: true,
+                }
+              } else {
+                put = template
+              }
+
+              rows.push({ strike, size, call, put })
+            }),
+          )
+        }),
+      )
+
+      rows.sort((a, b) => a.strike - b.strike)
+      setChain(rows)
+    },
+    [connection, dexProgramId, markets, uAsset, qAsset, setChain],
+  )
+
+  return { chain, fetchOptionsChain }
 }
 
-export default useOptionChain;
+export default useOptionChain

--- a/src/hooks/useOptionsMarkets.js
+++ b/src/hooks/useOptionsMarkets.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useCallback } from 'react'
+import React, { useContext, useCallback } from 'react'
 import BigNumber from 'bignumber.js'
 import { Link } from '@material-ui/core'
 import {
@@ -74,14 +74,16 @@ const useOptionsMarkets = () => {
 
         // BN.js doesn't handle decimals while bignumber.js can handle decimals of arbitrary sizes
         const amountPerContract = new BigNumber(
-          market.marketData.amountPerContract.toString(10)
+          market.marketData.amountPerContract.toString(10),
         ).div(10 ** uAsset.decimals)
 
         const quoteAmountPerContract = new BigNumber(
-          market.marketData.quoteAmountPerContract.toString(10)
+          market.marketData.quoteAmountPerContract.toString(10),
         ).div(10 ** qAsset.decimals)
 
-        const strike = quoteAmountPerContract.div(amountPerContract.toString(10))
+        const strike = quoteAmountPerContract.div(
+          amountPerContract.toString(10),
+        )
 
         const newMarket = {
           // Leave these in tact as BigNumbers to use later for creating the reciprocal put/call
@@ -119,10 +121,6 @@ const useOptionsMarkets = () => {
       console.error(err)
     }
   }, [connection, supportedAssets, endpoint]) // eslint-disable-line
-
-  useEffect(() => {
-    fetchMarketData()
-  }, [fetchMarketData])
 
   const getSizes = ({ uAssetSymbol, qAssetSymbol, date }) => {
     const keyPart = `${date}-${uAssetSymbol}-${qAssetSymbol}-`
@@ -407,6 +405,7 @@ const useOptionsMarkets = () => {
     getMyMarkets,
     mint,
     createAccountsAndMint,
+    fetchMarketData,
   }
 }
 


### PR DESCRIPTION
This isn't perfect, but it's a start.

What I changed:
- Remove useEffect from the useOptionsChain hook
- Return fetchOptionsChain from the options chain hook (also renamed from getOptionsChain to clarify that it doesn't return a value)
- Call fetchOptionsChain in the Markets page's useEffect
- Add more conditions to the fetchOptionsChain function to prevent the heavy parts of execution if we are missing some required data to actually do everything successfully
- Remove useEffect from useOptionsMarkets hook
- Call fetchMarketData in the useEffect of every page that needs the market data

The results:
For some reason useOptionChain is still firing twice on the Markets page, can't figure out why because none of the dependencies are changing from what I can tell. However it was firing about 20 times before, so 90% less times w/ only one extra rerender I'm happy with for now.
