### PR TITLE
Fix 100 percent height issues in firefox and safari

### DIFF
--- a/src/components/pages/Page.js
+++ b/src/components/pages/Page.js
@@ -23,7 +23,7 @@ const Page = ({ children, background }) => (
         flexGrow={1}
         justifyContent="center"
       >
-        <Box height="100%">{children}</Box>
+        <Box minHeight="100%">{children}</Box>
       </Box>
       <Footer />
     </Box>

--- a/src/components/server/template.js
+++ b/src/components/server/template.js
@@ -7,9 +7,10 @@ const baseCss = `
     box-sizing: border-box;
   }
 
-  html, body {
+  html, body, #app {
     width: 100%;
     min-height: 100%;
+    height: 100%;
     margin: 0;
     padding: 0;
   }


### PR DESCRIPTION
Mostly fixes #111 

Safari still has an issue which is that the page always extends beyond the bottom of the window size... but the footer is no longer overlapping other content on long pages. Safari is the new IE when it comes to flexbox, so I'm not too concerned about making it perfect until it becomes evident that there's any significant amount of Safari traffic.

Firefox looks perfect now though, before the page was not stretching vertically to fit the window height, now it is.