### PR TITLE
Show more dates

### DIFF
--- a/src/components/pages/InitializeMarket.js
+++ b/src/components/pages/InitializeMarket.js
@@ -133,7 +133,7 @@ const InitializeMarket = () => {
             Expires On:
             <Box display="flex" flexWrap="wrap">
               {expirations.map((moment) => {
-                const label = `${moment.format('ll')}, 00:00 UTC`
+                const label = `${moment.format('ll')}`
                 const selected = moment === date
                 const onClick = () => setDate(moment)
                 return (

--- a/src/components/pages/Markets/Markets.js
+++ b/src/components/pages/Markets/Markets.js
@@ -118,7 +118,7 @@ const Markets = () => {
                 onChange={(e) => setDate(e.target.value)}
                 options={expirations.map((d) => ({
                   value: d,
-                  text: `${d.format('ll')}, 00:00 UTC`,
+                  text: `${d.format('ll')} | 23:59:59 UTC`,
                 }))}
                 style={{
                   minWidth: '100%',

--- a/src/components/pages/Mint.js
+++ b/src/components/pages/Mint.js
@@ -139,7 +139,7 @@ const Mint = () => {
               Expires On:
               <Box display="flex" flexWrap="wrap">
                 {expirations.map((moment) => {
-                  const label = `${moment.format('ll')}, 00:00 UTC`
+                  const label = `${moment.format('ll')}`
                   const selected = moment === date
                   const onClick = () => {
                     setDate(moment)

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -1,11 +1,5 @@
 import moment from 'moment'
 
-// export const getNext3Months = () => [
-//   moment.utc().startOf('month').add(1, 'month'),
-//   moment.utc().startOf('month').add(2, 'month'),
-//   moment.utc().startOf('month').add(3, 'month'),
-// ]
-
 const subtractDays = [2, 3, 4, 5, 6, 0, 1]
 
 export const getLastFridayOfMonths = (n = 10) =>


### PR DESCRIPTION
Use last Friday of each month for all expirations, and show more dates at a time. Now we'll be showing 10 months out which is what Deribit does.

Not sure if the contracts should expire at 0:00 UTC time if the date is Friday. I'm wondering if we should make it 23:59:59 in that case to make it so all day on the last Friday is fair game. Might be confusing otherwise.

![Screen Shot 2021-03-17 at 2 29 08 PM](https://user-images.githubusercontent.com/9023427/111519497-8afc4a00-872d-11eb-9f69-6165d7ef266e.png)
![Screen Shot 2021-03-17 at 2 29 10 PM](https://user-images.githubusercontent.com/9023427/111519516-8e8fd100-872d-11eb-8cc4-60d2bd8d9d61.png)

