### PR TITLE
Refactor connection context and asset list context to fix bug and potentially reduce rerenders

### DIFF
--- a/src/context/ConnectionContext.js
+++ b/src/context/ConnectionContext.js
@@ -1,6 +1,8 @@
 import React, { createContext, useState } from 'react'
 import useLocalStorageState from 'use-local-storage-state'
-import { getDexProgramKeyByNetwork, networks } from '../utils/networkInfo';
+import { Connection } from '@solana/web3.js'
+
+import { getDexProgramKeyByNetwork, networks } from '../utils/networkInfo'
 
 // Default to first network that has a defined program id
 const DEFAULT_NETWORK = networks.find(
@@ -14,16 +16,24 @@ const ConnectionProvider = ({ children }) => {
     'endpoint',
     DEFAULT_NETWORK,
   )
-  const [connection, setConnection] = useState({})
 
-  // TODO: move all this into a useReducer() state, get rid of useState() here
+  const [connection, setConnection] = useState(
+    new Connection(endpoint.url, 'confirmed'),
+  )
+
+  const handleSetEndpoint = (newEndpoint) => {
+    // Update both endpoint and connection state valuse in the same function
+    // Will prevent extra rerenders of components that depend on both endpoint and connection
+    setEndpoint(newEndpoint)
+    setConnection(new Connection(newEndpoint.url, 'confirmed'))
+  }
 
   const state = {
     networks,
     connection,
     setConnection,
     endpoint,
-    setEndpoint,
+    setEndpoint: handleSetEndpoint,
     dexProgramId: getDexProgramKeyByNetwork(endpoint.name),
   }
 

--- a/src/hooks/useConnection.js
+++ b/src/hooks/useConnection.js
@@ -1,21 +1,14 @@
-import { Connection } from '@solana/web3.js'
-import { useContext, useEffect } from 'react'
+import { useContext } from 'react'
 import { ConnectionContext } from '../context/ConnectionContext'
 
 const useConnection = () => {
   const {
     networks,
     connection,
-    setConnection,
     endpoint,
     setEndpoint,
     dexProgramId,
   } = useContext(ConnectionContext)
-
-  useEffect(() => {
-    const cx = new Connection(endpoint.url, 'confirmed')
-    setConnection(cx)
-  }, [endpoint, setConnection])
 
   return {
     networks,


### PR DESCRIPTION
The gist of the change is pretty much instead of updating the connection in a useEffect when the endpoint value changes, I just make the setEndpoint function that's exposed to the UI change both the connection instance and the endpoint value synchronously. Didn't realize when I first created this context that the "connection" type wouldn't have any async initialization phase, but now useEffect has been completely removed from the connection context, so anything depending on useConnection should only be triggered to update once when the app first loads, and once each time the user selects a different network.

Also, for the asset list context, there were two separate useEffects, one to populate the asset list w/ onchain data, and one to set the default assets. I've combined these now, but these will have to remain inside of a useEffect because of the asynchronous stuff going on.