### PR TITLE
Bugfixes: Adding loading states and improving the async/await waterfall

### DIFF
--- a/src/components/pages/Markets/Markets.js
+++ b/src/components/pages/Markets/Markets.js
@@ -14,7 +14,6 @@ import { getLastFridayOfMonths } from '../../../utils/dates'
 
 import useAssetList from '../../../hooks/useAssetList'
 import useOptionsChain from '../../../hooks/useOptionsChain'
-import useOptionsMarkets from '../../../hooks/useOptionsMarkets'
 
 import CallPutRow from './CallPutRow'
 import BuySellDialog from '../../BuySellDialog'
@@ -62,7 +61,7 @@ const Markets = () => {
   const { uAsset, qAsset, setUAsset, setQAsset } = useAssetList()
   const [date, setDate] = useState(expirations[0])
   const { chain, fetchOptionsChain } = useOptionsChain()
-  const { fetchMarketData } = useOptionsMarkets()
+  // const { fetchMarketData } = useOptionsMarkets()
   const [round, setRound] = useState(true) // TODO make this a user toggle-able feature
 
   const [buySellDialogOpen, setBuySellDialogOpen] = useState(false)
@@ -82,12 +81,13 @@ const Markets = () => {
 
   const rows = [
     ...chain,
-    ...Array(Math.max(9 - chain.length, 0)).fill(rowTemplate),
+    ...Array(Math.max(9 - chain.length, 0))
+      .fill(rowTemplate)
+      .map((row, i) => ({
+        ...row,
+        key: `empty-${i}`,
+      })),
   ]
-
-  useEffect(() => {
-    fetchMarketData()
-  }, [fetchMarketData])
 
   useEffect(() => {
     fetchOptionsChain(date.unix())
@@ -254,19 +254,21 @@ const Markets = () => {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {rows.map((row, i) => (
-                  <CallPutRow
-                    key={i}
-                    row={row}
-                    uAsset={uAsset}
-                    qAsset={qAsset}
-                    date={date}
-                    precision={precision}
-                    round={round}
-                    onClickBuySellCall={handleBuySellClick}
-                    onClickBuySellPut={handleBuySellClick}
-                  />
-                ))}
+                {rows.map((row) => {
+                  return (
+                    <CallPutRow
+                      key={`${row.key}`}
+                      row={row}
+                      uAsset={uAsset}
+                      qAsset={qAsset}
+                      date={date}
+                      precision={precision}
+                      round={round}
+                      onClickBuySellCall={handleBuySellClick}
+                      onClickBuySellPut={handleBuySellClick}
+                    />
+                  )
+                })}
               </TableBody>
             </Table>
           </TableContainer>

--- a/src/context/AssetListContext.js
+++ b/src/context/AssetListContext.js
@@ -48,6 +48,7 @@ const AssetListProvider = ({ children }) => {
   const [supportedAssets, setSupportedAssets] = useState([])
   const [uAsset, setUAsset] = useState()
   const [qAsset, setQAsset] = useState()
+  const [assetListLoading, setAssetListLoading] = useState(false)
   const { pushNotification } = useNotifications()
 
   useEffect(() => {
@@ -81,6 +82,7 @@ const AssetListProvider = ({ children }) => {
     }
 
     const loadAssets = async (basicAssets) => {
+      setAssetListLoading(true)
       try {
         const mergedAssets = await mergeAssetsWithChainData(
           connection,
@@ -98,12 +100,14 @@ const AssetListProvider = ({ children }) => {
           .map((res) => res.value)
         setSupportedAssets(loadedAssets)
         setDefaultAssets(loadedAssets)
+        setAssetListLoading(false)
       } catch (error) {
         pushNotification({
           severity: 'error',
           message: `${error}`,
         })
         console.error(error)
+        setAssetListLoading(false)
         setSupportedAssets([])
       }
     }
@@ -114,10 +118,12 @@ const AssetListProvider = ({ children }) => {
 
   const value = {
     supportedAssets,
+    setSupportedAssets,
     uAsset,
     qAsset,
     setUAsset,
     setQAsset,
+    assetListLoading,
   }
 
   return (

--- a/src/context/OptionsChainContext.js
+++ b/src/context/OptionsChainContext.js
@@ -5,10 +5,12 @@ const OptionsChainContext = createContext()
 
 const OptionsChainProvider = ({ children }) => {
   const [chain, setChain] = useState([])
-  const [loading, setLoading] = useState(false)
+  const [optionsChainLoading, setOptionsChainLoading] = useState(false)
 
   return (
-    <OptionsChainContext.Provider value={{ chain, setChain, loading, setLoading }}>
+    <OptionsChainContext.Provider
+      value={{ chain, setChain, optionsChainLoading, setOptionsChainLoading }}
+    >
       {children}
     </OptionsChainContext.Provider>
   )

--- a/src/context/OptionsMarketsContext.js
+++ b/src/context/OptionsMarketsContext.js
@@ -5,9 +5,12 @@ const OptionsMarketsContext = createContext()
 
 const OptionsMarketsProvider = ({ children }) => {
   const [markets, setMarkets] = useState({})
+  const [marketsLoading, setMarketsLoading] = useState(false)
 
   return (
-    <OptionsMarketsContext.Provider value={{ markets, setMarkets }}>
+    <OptionsMarketsContext.Provider
+      value={{ markets, setMarkets, marketsLoading, setMarketsLoading }}
+    >
       {children}
     </OptionsMarketsContext.Provider>
   )


### PR DESCRIPTION
I put in some more time to work through some of the jankiness in the loading of the options chain in the app, and it came down to a few important things:

There's essentially a 3 stage async waterfall of on-chain data fetching required to load the options chain. Step 1 is the load the supported assets. Step 2 is to load the options markets data. Step 3 is to load the options chain (the async part of this is the serum part)

Some of the jankiness was coming from:
1. Supported assets not being the supported assets of the correct network before calling fetchMarketData. We were checking if the supportedAssets exist, but not that they were from the correct network (devnet vs local). To fix this, I updated the network select menu to reset the supported assets when changing networks

2. When going from the initialize or open positions page to the Markets page, old Markets data was already loaded. This caused the fetchOptionsChain to trigger in addition to a new fetchMarketData that would load the latest market data. When this fetchMarketData completed, it triggered fetchOptionsChain to fire again because the markets data changed. To correct this, I removed fetchMarketData from the Markets page, and added an "await fetchMarketsData()" inside of fetchOptionsChain. So fetchOptionsChain now does both sequentially. Now it doesn't care if the market data already exists, it will replace whatever market data was there already. But the markets page will only make this call, so we won't see two fetchOptionsChain calls from the markets page now.

3. Update the jsx map of the options chain rows to actually include meaningful keys. I believe improper keys were causing the rows to show a mix of data if there were overlapping fetchMarketData or fetchOptionsChain results from switching networks and the calls to each network racing each other

4. To solve the network racing issue, I also made the network select reset all the chain data and market data when you select a new network, and then disable switching networks while new options chain data or market data is loading. This is a bit annoying when you're switching to dev, because dev takes several seconds to load this whole "async waterfall". I was counting about 6-10 seconds most of the time. I'm not sure how we can better the user experience for this other than just making our network calls for on-chain data more efficient. Maybe mainnet is a little faster than devnet, not really sure. Adding more and prettier looking "loading" states to all of the components of the app would help as well. Right now I just threw a spinner in the network dropdown and that's it.

Didn't really test the open positions page after these changes, but I think it should be fine, since it's just using fetchMarketData and not the options chain. 

Future improvement:
One other thing we are doing is fetching new market data on every page change. This is nice to have because it makes sure we have updated on-chain data every time we switch pages, so for example when initializing a market from the initialize page, we can go back to the markets page and query for the on-chain results, instead of having to manage a local state that we hope is synced to the on-chain state.
However it might be better to just not update the market data when switching pages, and then add a manual refresh button (raydium does this with their pools). Would make page switching faster and in any cases where you aren't initializing new markets it would be a better experience. If you initialized a new market and don't see it in the options chain, you can just manually hit the refresh button and get the new data without refreshing the whole page and having to re-connect your wallet.