### PR TITLE
Lock down quote asset to USDC

### DIFF
--- a/src/components/SelectAsset.js
+++ b/src/components/SelectAsset.js
@@ -9,13 +9,21 @@ import {
   Avatar,
   ListItemText,
   useTheme,
+  withStyles,
 } from '@material-ui/core'
 import KeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown'
 import { debounce } from 'throttle-debounce'
 
 import useAssetList from '../hooks/useAssetList'
 
-const SelectAsset = ({ label, selectedAsset, onSelectAsset }) => {
+const CustomChip = withStyles({
+  disabled: {
+    border: '1px solid transparent',
+    opacity: '1 !important',
+  },
+})(Chip)
+
+const SelectAsset = ({ label, selectedAsset, onSelectAsset, disabled }) => {
   const theme = useTheme()
   const { supportedAssets, assetListLoading } = useAssetList()
 
@@ -25,8 +33,9 @@ const SelectAsset = ({ label, selectedAsset, onSelectAsset }) => {
   const filteredAssetList = supportedAssets.filter((item) => {
     const match = filterInput.toLowerCase()
     const shouldAppear =
-      item.tokenName.toLowerCase().match(match) ||
-      item.tokenSymbol.toLowerCase().match(match)
+      (item.tokenName.toLowerCase().match(match) ||
+        item.tokenSymbol.toLowerCase().match(match)) &&
+      !item.tokenSymbol.toLowerCase().match('usdc')
     return shouldAppear
   })
 
@@ -41,7 +50,7 @@ const SelectAsset = ({ label, selectedAsset, onSelectAsset }) => {
 
   const chipLabel = assetListLoading
     ? 'Loading...'
-    : selectedAsset?.tokenName || 'Choose Asset'
+    : selectedAsset?.tokenSymbol || 'Choose Asset'
 
   return (
     <>
@@ -90,11 +99,12 @@ const SelectAsset = ({ label, selectedAsset, onSelectAsset }) => {
           </Box>
         </Box>
       </Dialog>
-      <Chip
+      <CustomChip
         label={chipLabel}
-        clickable
-        color="primary"
+        clickable={!disabled}
+        color={'primary'}
         variant="outlined"
+        disabled={disabled}
         avatar={
           selectedAsset ? (
             <Avatar
@@ -108,9 +118,9 @@ const SelectAsset = ({ label, selectedAsset, onSelectAsset }) => {
             </Avatar>
           ) : null
         }
-        onClick={handleOpen}
-        onDelete={handleOpen}
-        deleteIcon={<KeyboardArrowDown />}
+        onClick={disabled ? null : handleOpen}
+        onDelete={disabled ? null : handleOpen}
+        deleteIcon={disabled ? null : <KeyboardArrowDown />}
       />
     </>
   )

--- a/src/components/pages/InitializeMarket.js
+++ b/src/components/pages/InitializeMarket.js
@@ -35,7 +35,7 @@ const InitializeMarket = () => {
   const [multiple, setMultiple] = useState(false)
   const [basePrice, setBasePrice] = useState(0)
   const [date, setDate] = useState(expirations[0])
-  const { uAsset, qAsset, setUAsset, setQAsset } = useAssetList()
+  const { uAsset, qAsset, setUAsset } = useAssetList()
   const [size, setSize] = useState(0)
   const [priceInterval, setPriceInterval] = useState(0)
   const { marketPrice } = useSerumMarketInfo({
@@ -160,9 +160,6 @@ const InitializeMarket = () => {
                 <SelectAsset
                   selectedAsset={uAsset}
                   onSelectAsset={(asset) => {
-                    if (asset === qAsset) {
-                      setQAsset(uAsset)
-                    }
                     setUAsset(asset)
                   }}
                 />
@@ -172,15 +169,7 @@ const InitializeMarket = () => {
             <Box width="50%" p={2}>
               Quote Asset:
               <Box mt={2}>
-                <SelectAsset
-                  selectedAsset={qAsset}
-                  onSelectAsset={(asset) => {
-                    if (asset === uAsset) {
-                      setUAsset(qAsset)
-                    }
-                    setQAsset(asset)
-                  }}
-                />
+                <SelectAsset selectedAsset={qAsset} disabled />
               </Box>
             </Box>
           </Box>

--- a/src/components/pages/Markets/Markets.js
+++ b/src/components/pages/Markets/Markets.js
@@ -95,13 +95,7 @@ const rowTemplate = {
 const expirations = getLastFridayOfMonths(10)
 
 const Markets = () => {
-  const {
-    uAsset,
-    qAsset,
-    setUAsset,
-    setQAsset,
-    assetListLoading,
-  } = useAssetList()
+  const { uAsset, qAsset, setUAsset, assetListLoading } = useAssetList()
   const [date, setDate] = useState(expirations[0])
   const { chain, fetchOptionsChain } = useOptionsChain()
   const { marketsLoading, fetchMarketData } = useOptionsMarkets()
@@ -213,41 +207,31 @@ const Markets = () => {
               />
             </Box>
           </Box>
-          <Box
-            px={[1, 1, 0]}
-            py={[2, 2, 1]}
-            width={['100%', '100%', 'auto']}
-            fontSize="12px"
-            display="flex"
-            alignItems="center"
-          >
-            <Box px={1}>
-              <Box>
-                <SelectAsset
-                  selectedAsset={uAsset}
-                  onSelectAsset={(asset) => {
-                    if (asset === qAsset) {
-                      setQAsset(uAsset)
-                    }
-                    setUAsset(asset)
-                  }}
-                />
+          <Box px={[1, 1, 0]} py={[2, 2, 1]} width={['100%', '100%', 'auto']}>
+            <Box pb={'6px'} pl="10px" fontSize={'11px'}>
+              Asset Pair:
+            </Box>
+            <Box
+              fontSize="12px"
+              display="flex"
+              alignItems="center"
+              border={`1px solid ${theme.palette.background.lighter}`}
+              borderRadius={'20px'}
+              width={'fit-content'}
+            >
+              <Box pr={1}>
+                <Box>
+                  <SelectAsset
+                    selectedAsset={uAsset}
+                    onSelectAsset={(asset) => {
+                      setUAsset(asset)
+                    }}
+                  />
+                </Box>
               </Box>
-            </Box>
-            <Box>
               <h3 style={{ margin: 0 }}>/</h3>
-            </Box>
-            <Box pl={1} pr={[1, 1, 0]}>
-              <Box>
-                <SelectAsset
-                  selectedAsset={qAsset}
-                  onSelectAsset={(asset) => {
-                    if (asset === uAsset) {
-                      setUAsset(qAsset)
-                    }
-                    setQAsset(asset)
-                  }}
-                />
+              <Box pl={'4px'}>
+                <SelectAsset disabled selectedAsset={qAsset} />
               </Box>
             </Box>
           </Box>

--- a/src/components/pages/Mint.js
+++ b/src/components/pages/Mint.js
@@ -36,7 +36,7 @@ const Mint = () => {
   const dates = expirations
 
   const [date, setDate] = useState(dates[0])
-  const { uAsset, qAsset, setUAsset, setQAsset } = useAssetList()
+  const { uAsset, qAsset, setUAsset } = useAssetList()
   const [size, setSize] = useState(100)
   const [price, setPrice] = useState('')
   const [uAssetAccount, setUAssetAccount] = useState('')
@@ -71,7 +71,8 @@ const Mint = () => {
     [marketData, ownedTokenAccounts],
   )
   const ownedWriterTokenMintAccounts = useMemo(
-    () => (marketData && ownedTokenAccounts[marketData.writerTokenMintKey]) || [],
+    () =>
+      (marketData && ownedTokenAccounts[marketData.writerTokenMintKey]) || [],
     [marketData, ownedTokenAccounts],
   )
 
@@ -183,9 +184,6 @@ const Mint = () => {
                   <SelectAsset
                     selectedAsset={uAsset}
                     onSelectAsset={(asset) => {
-                      if (asset === qAsset) {
-                        setQAsset(uAsset)
-                      }
                       setUAsset(asset)
                       setPrice('')
                     }}
@@ -213,16 +211,7 @@ const Mint = () => {
               <Box width="50%" p={2}>
                 Quote Asset:
                 <Box my={2}>
-                  <SelectAsset
-                    selectedAsset={qAsset}
-                    onSelectAsset={(asset) => {
-                      if (asset === uAsset) {
-                        setUAsset(qAsset)
-                      }
-                      setQAsset(asset)
-                      setPrice('')
-                    }}
-                  />
+                  <SelectAsset selectedAsset={qAsset} disabled />
                 </Box>
                 {ownedQAssetAccounts.length > 1 ? (
                   <Select


### PR DESCRIPTION
Also updated the markets page UI to make it look more like they're a pair, not just two totally separate things, and added "Asset Pair:" above.

I think the ideal setup in the future is to eventually begin storing a list of supported pairs. That way the "pair" always has the same quote asset and you won't be able to "flip" the quote and underlying asset in the UI, but we can still add some less orthodox pairs such as "BTC/ETH" for example if the community shows interest in that sort of thing. Of course we would add all the USDC pairs we started out with as well at that point

Screens:
![Screen Shot 2021-03-29 at 4 38 43 PM](https://user-images.githubusercontent.com/9023427/112897785-09ea6e80-90ae-11eb-8ffc-a95af8aed252.png)

![Screen Shot 2021-03-29 at 4 44 21 PM](https://user-images.githubusercontent.com/9023427/112897811-11aa1300-90ae-11eb-8075-d33d79f8776a.png)

![Screen Shot 2021-03-29 at 4 04 06 PM](https://user-images.githubusercontent.com/9023427/112897834-18388a80-90ae-11eb-8927-4a9c1b729af7.png)

