### PR TITLE
Make some updates to the readme and example env file

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,25 +1,21 @@
-
-# Program accounts for the options smart contract
-LOCAL_PROGRAM_ID='3oRDBQibfrhKzwwYVB6MchD1cbGZ7GK1ue9rVSbD3vXX'
+# Program ids for PsyOptions:
+# LOCAL_PROGRAM_ID=''
 DEVNET_PROGRAM_ID='CgetkVhjkbdB3sYpAHZBTWVzojroqKqsZjkXxSP3kF3g'
-# TESTNET_PROGRAM_ID='3oRDBQibfrhKzwwYVB6MchD1cbGZ7GK1ue9rVSbD3vXX'
-# MAINNET_PROGRAM_ID='3oRDBQibfrhKzwwYVB6MchD1cbGZ7GK1ue9rVSbD3vXX'
+# TESTNET_PROGRAM_ID=''
+# MAINNET_PROGRAM_ID=''
 
-# Serum DEX program accounts
-LOCAL_DEX_PROGRAM_ID='HrRJzsMD7ZwGBtedkd3zqmsDyz7Fj2kpLCFaCgAbgLwC'
-DEVNET_DEX_PROGRAM_ID='9MVDeYQnJmN2Dt7H44Z8cob4bET2ysdNu2uFJcatDJno'
-# TESTNET_DEX_PROGRAM_ID='9MVDeYQnJmN2Dt7H44Z8cob4bET2ysdNu2uFJcatDJno'
+# Program ids for Serum Dex:
+# LOCAL_DEX_PROGRAM_ID=''
+DEVNET_DEX_PROGRAM_ID='DESVgJVGajEgKGXhb6XmqDHGz3VjdgP7rEVESBgxmroY'
+# TESTNET_DEX_PROGRAM_ID=''
+# MAINNET_DEX_PROGRAM_ID=''
 
-# Mainnet serum DEX id will be imported from serum-ts
-
-OPTIONS_API_URL=http://localhost:8080
-
-# Turn this on to actually use the app
-# Remove this to make the app serve the "coming soon" page
+# Remove/comment this to make the app serve the "coming soon" page:
 APP_ENABLED=true
 
-# Flag to enable password protection
+# Uncomment this to enable password protection:
 # APP_PASSWORD_PROTECTED=true
 
-# This should be a sha1 hash of the password
-# APP_PASSWORD=
+# The password as a sha1 hash (uncomment if password protection is enabled)
+# The example here is the sha1 of the password "psyopts":
+# APP_PASSWORD='89fe0dbb9a8e940c4e88f40ae9738db57dbe38a8'

--- a/README.md
+++ b/README.md
@@ -1,61 +1,79 @@
-## Seeding LocalNet
-To use a local net keypair file run `npm run seed -- PATH_TO_KEYPAIR_FILE`. This script will **not** airdrop SOL, so be sure to have enough in the account or use the [solana cli](https://docs.solana.com/cli/transfer-tokens#testing-your-wallet) to airdrop prior to seeding. 
+## Configuring the app for local development:
 
-You can also seed without the keypair file by running `npm run seed`. 
+Copy `.env-example` and rename it `.env`
+
+OR run `touch .env` and add the following lines to it:
+
+```
+DEVNET_PROGRAM_ID='CgetkVhjkbdB3sYpAHZBTWVzojroqKqsZjkXxSP3kF3g'
+DEVNET_DEX_PROGRAM_ID='DESVgJVGajEgKGXhb6XmqDHGz3VjdgP7rEVESBgxmroY'
+APP_ENABLED=true
+```
+
+## Seeding LocalNet
+
+To use a local net keypair file run `npm run seed -- PATH_TO_KEYPAIR_FILE`. This script will **not** airdrop SOL, so be sure to have enough in the account or use the [solana cli](https://docs.solana.com/cli/transfer-tokens#testing-your-wallet) to airdrop prior to seeding.
+
+You can also seed without the keypair file by running `npm run seed`.
 
 Using the keypair file will allow you to mint the SPL tokens the seed generates because the keypair will be the authority of those mints. You can then create the necessary token accounts with the [solana-token cli](https://spl.solana.com/token).
 
 To generate accounts and mint some of the newly generated SPL Tokens run `npm run seed:mintTokens -- PATH_TO_KEYPAIR_FILE WALLET_ADDRESS`. Specify `WALLET_ADDRESS` which will be the owner of the new accounts.
 
 ## Scripts
-### Deploying Serum
-Set your `solana` configs appropriately. Then run the deployer with `node scripts/deploySerum.js`. 
 
-| Option Flags | Description |
-| ------------ | ----------- |
-| --airdrop | An integer value that determines how much SOL to airdrop to the keypair before running the deployer |
-| --pullDex | A truthy value to indicate the script should download the latest dex binary from mainnet |
+### Deploying Serum
+
+Set your `solana` configs appropriately. Then run the deployer with `node scripts/deploySerum.js`.
+
+| Option Flags | Description                                                                                         |
+| ------------ | --------------------------------------------------------------------------------------------------- |
+| --airdrop    | An integer value that determines how much SOL to airdrop to the keypair before running the deployer |
+| --pullDex    | A truthy value to indicate the script should download the latest dex binary from mainnet            |
 
 ### Initialize Serum
+
 NOTE: After many hours failing to intiialize on local net due to the following error `Program failed to complete: Access violation in unknown section at address 0x27f2f7ac290d7fe9 of size 1 by instruction #18168` we are working on a script to ensure Devnet contains Serum markets and data necessary to give the full experience of the protocol and UI.
 
 1. Set your `solana` config to your Devnet configuration (i.e. change the url and the keypair being used)
 2. Make sure you airdrop some SOL `solana airdrop 10`
 3. Run the initialize market script `npx babel-node scripts/initializeSerumMarket.js --baseMint=BASE_MINT --quoteMint=QUOTE_MINT`
 
+## Interacting on Devnet
 
-## Interacting on Devnet 
 We use a couple SPL Token faucets to interact on devnet. To use the faucets visit this community built site and be sure to set the network to **devnet**.
 https://spl-token-ui.netlify.app/#/token-faucets
 
-````
+```
 Token Symbol: PSYA
 Faucet Address: 7jJJnHWagPPG544FtxSVp8eD52FwCsARcqqup1q3XVio
 Mint Address: BzwRWwr1kCLJVUUM14fQthP6FJKrGpXjw3ZHTZ6PQsYa
-````
+```
 
-````
+```
 Token Symbol: USDCT
 Faucet Address: BmaVN3Wut1k2MtrcsxjTn919GdBJ2gzVLTtbiybnAPnR
 Mint Address: HinfVnJuzMtJsyuLE2ArYCChDZB6FCxEu2p3CQeMcDiF
-````
+```
 
 ### Example: To Airdrop PSYA Tokens
+
 1. Go to Sollet.io
 2. Set netowrk to **DEVNET**
 3. Click + to add a token account manually. Enter the following and submit
-````
- Token Mint Address: _BzwRWwr1kCLJVUUM14fQthP6FJKrGpXjw3ZHTZ6PQsYa_  
+
+```
+ Token Mint Address: _BzwRWwr1kCLJVUUM14fQthP6FJKrGpXjw3ZHTZ6PQsYa_
  Token Name: PSYA Test
  Token Symbol: PSYA
-````
+```
+
 4. Head to the [Token Faucet](https://spl-token-ui.netlify.app/#/token-faucets) to perform a "Token Airdrop". Enter the following
-````
+
+```
 Token Destination Address: The "Deposit Address" from the token account you just created on Sollet
 Faucet Address: 7jJJnHWagPPG544FtxSVp8eD52FwCsARcqqup1q3XVio
 Amount: 1000000000000 (or whatever you feel)
-````
-
-
+```
 
 DEV cloud run url: https://solana-options-frontend-ckpgwptysa-uc.a.run.app/


### PR DESCRIPTION
The example env file still had the old serum devnet program id in it, and the readme did not mention how to set up the env file for local development against devnet. Anyone who hasn't used the dotenv module before might not know what to do with it. I also removed the mainnet program id and my local program ids from the example env file since we want to be working off of devnet unless there's a specific program/binding change we need to test locally from the UI