### PR TITLE
Update favicon and docs link on landing

### DIFF
--- a/src/components/pages/Landing.js
+++ b/src/components/pages/Landing.js
@@ -214,6 +214,8 @@ const Landing = () => {
                 color="primary"
                 variant="outlined"
                 style={{ whiteSpace: 'nowrap' }}
+                href="https://docs.psyoptions.io"
+                target="_blank"
               >
                 Read Docs
               </Button>

--- a/src/components/server/template.js
+++ b/src/components/server/template.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import theme from '../../utils/theme'
-import favicon from '../../../assets/psyoptions-logo-secondary.png'
+import favicon from '../../../assets/psyoptions-logo-small.png'
 
 const baseCss = `
   * {


### PR DESCRIPTION
Changes:
- Switched favicon to the gradient logo which is used on docs site etc.
- Added link to docs site on the landing page (forgot this one before)