### PR TITLE
Fix toString of undefined error in open positions page

### DIFF
--- a/src/components/pages/OpenPositions/PositionRow.tsx
+++ b/src/components/pages/OpenPositions/PositionRow.tsx
@@ -64,9 +64,9 @@ const PositionRow: React.VFC<{
   const { exercise } = useExerciseOpenPosition(
     row.market,
     // TODO remove `toString` when useExerciseOpenPosition is refactored
-    ownedQAssetKey.toString(),
-    ownedUAssetKey.toString(),
-    ownedOAssetKey.toString(),
+    ownedQAssetKey && ownedQAssetKey.toString(),
+    ownedUAssetKey && ownedUAssetKey.toString(),
+    ownedOAssetKey && ownedOAssetKey.toString(),
   )
 
   const handleExercisePosition = async () => {


### PR DESCRIPTION
Saw this happening in the Open Positions page when I had SOL options in my wallet. I'm not totally sure why it only happened for SOL but this should take care of it.