### PR TITLE
Add env variable to disable initialize page

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -19,3 +19,6 @@ APP_ENABLED=true
 # The password as a sha1 hash (uncomment if password protection is enabled)
 # The example here is the sha1 of the password "psyopts":
 # APP_PASSWORD='89fe0dbb9a8e940c4e88f40ae9738db57dbe38a8'
+
+# If uncommented, enable the initialize markets page
+INITIALIZE_PAGE_ENABLED=true

--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -15,7 +15,11 @@ import History from './pages/History'
 import Markets from './pages/Markets'
 import NotFound from './pages/NotFound'
 
-const { APP_PASSWORD_PROTECTED, APP_PASSWORD } = process.env
+const {
+  INITIALIZE_PAGE_ENABLED,
+  APP_PASSWORD_PROTECTED,
+  APP_PASSWORD,
+} = process.env
 
 const Router = isBrowser ? BrowserRouter : StaticRouter
 
@@ -58,9 +62,11 @@ const Routes = (props) => {
         <Route exact path="/markets">
           <Markets />
         </Route>
-        <Route exact path="/initialize-market">
-          <InitializeMarket />
-        </Route>
+        {INITIALIZE_PAGE_ENABLED && (
+          <Route exact path="/initialize-market">
+            <InitializeMarket />
+          </Route>
+        )}
         <Route exact path="/mint">
           <Mint />
         </Route>

--- a/src/components/StatusBar.js
+++ b/src/components/StatusBar.js
@@ -15,6 +15,8 @@ import theme from '../utils/theme'
 
 import logo from '../../assets/psyoptions-logo-light.png'
 
+const { INITIALIZE_PAGE_ENABLED } = process.env
+
 const NavOptions = React.memo(() => {
   const history = useHistory()
 
@@ -45,17 +47,19 @@ const NavOptions = React.memo(() => {
           Markets
         </Button>
       </Box>
-      <Box mx={2}>
-        <Button
-          href="/initialize-market"
-          onClick={(e) => {
-            e.preventDefault()
-            history.push('/initialize-market')
-          }}
-        >
-          Initialize
-        </Button>
-      </Box>
+      {INITIALIZE_PAGE_ENABLED && (
+        <Box mx={2}>
+          <Button
+            href="/initialize-market"
+            onClick={(e) => {
+              e.preventDefault()
+              history.push('/initialize-market')
+            }}
+          >
+            Initialize
+          </Button>
+        </Box>
+      )}
       <Box mx={2}>
         <Button
           href="/open-positions"

--- a/src/server.js
+++ b/src/server.js
@@ -49,6 +49,7 @@ const {
   APP_ENABLED = false,
   APP_PASSWORD,
   APP_PASSWORD_PROTECTED,
+  INITIALIZE_PAGE_ENABLED,
 } = process.env
 
 server.use((req, res) => {
@@ -77,6 +78,7 @@ server.use((req, res) => {
         OPTIONS_API_URL,
         APP_PASSWORD,
         APP_PASSWORD_PROTECTED,
+        INITIALIZE_PAGE_ENABLED,
       }
     } else {
       app = <LandingComingSoon />


### PR DESCRIPTION
Pretty straight forward, with this we can disable the page in production but still use it on localhost or the dev instance to create markets. Also this doesn't disable the initialize button on the matching call/put if it doesn't exist in the chain.