### PR TITLE
Fix not iterable error

### DIFF
--- a/src/components/OpenOrders/OpenOrdersForMarket.tsx
+++ b/src/components/OpenOrders/OpenOrdersForMarket.tsx
@@ -7,6 +7,7 @@ import useSerum from '../../hooks/useSerum'
 import { useSerumOpenOrders } from '../../context/SerumOpenOrdersContext'
 import { useSerumOrderbooks } from '../../context/SerumOrderbookContext'
 import { useSubscribeOpenOrders, useSettleFunds } from '../../hooks/Serum'
+import useNotifications from '../../hooks/useNotifications'
 
 import { TCell } from './OpenOrderStyles'
 
@@ -35,6 +36,7 @@ const OpenOrdersForMarket: React.FC<{
   const [openOrders] = useSerumOpenOrders()
   const { serumMarket } = serumMarkets[serumKey] || {}
   const settleFunds = useSettleFunds(serumKey)
+  const { pushNotification } = useNotifications()
 
   useSubscribeOpenOrders(serumKey)
 
@@ -64,7 +66,11 @@ const OpenOrdersForMarket: React.FC<{
       openOrders[serumKey]?.orders || [],
     )
   } catch (err) {
-    console.log(err)
+    pushNotification({
+      severity: 'error',
+      message: `Couldn't display open orders for option market: ${uAssetSymbol}/${qAssetSymbol} ${type} @ strike ${strikePrice}`,
+    })
+    console.error(err)
   }
 
   return (


### PR DESCRIPTION
I noticed this error on the dev instance coming from the code `serumMarket.market.filterForOpenOrders`, I'm not sure which argument was not iterable because we didn't have sourcemaps uploaded, but this should help. It's kinda hard to test because it's not easily reproducible, seems to happen when something passed into that function is undefined or the wrong type. Couldn't tell which it was though, so I made sure to fall back to empty array for each argument and also wrap it in a try catch for good measure.
![Screen Shot 2021-05-02 at 5 32 18 PM](https://user-images.githubusercontent.com/9023427/116828639-f0858800-ab6d-11eb-9251-8061b5022441.png)
