### PR TITLE
Improve failure state for mark price fetch

### DIFF
--- a/src/components/pages/Markets/Markets.js
+++ b/src/components/pages/Markets/Markets.js
@@ -410,7 +410,7 @@ const Markets = () => {
             alignItems="center"
           >
             <Box>
-              {uAsset && uAsset.tokenSymbol && markPrice && (
+              {!!uAsset?.tokenSymbol && !!markPrice && (
                 <>
                   {uAsset?.tokenSymbol} Market Price: $
                   {markPrice && markPrice.toFixed(precision)}

--- a/src/hooks/useBonfidaMarkPrice.js
+++ b/src/hooks/useBonfidaMarkPrice.js
@@ -7,6 +7,7 @@ export const useBonfidaMarkPrice = ({ uAsset, qAsset }) => {
   const { pushNotification } = useNotifications()
 
   useEffect(() => {
+    setMarkPrice(0)
     let timer
     if (uAsset?.tokenSymbol && qAsset?.tokenSymbol) {
       const fetchPrice = async () => {
@@ -22,6 +23,9 @@ export const useBonfidaMarkPrice = ({ uAsset, qAsset }) => {
             setMarkPrice(0)
           }
         } catch (err) {
+          // Stop polling on failure to prevent error messages from popping up repeatedly
+          clearInterval(timer)
+          setMarkPrice(0)
           pushNotification({
             severity: 'error',
             message: `Couldn't load market price for ${uAsset?.tokenSymbol}`,


### PR DESCRIPTION
Before:
- If the asset doesn't exist on mainnet, like for PSY, it repeatedly fails due to polling continuing to run even after failure and pops up a notification message every time
- It displays a lone "0" where the market price should be displayed
- If there was already another market price loaded before, it actually displays the old price instead

After:
- It clears the market price every time you change assets so that it displays nothing if the new call fails
- It stops polling if it fails, so that you stop seeing errors. The polling will restart when changing assets to something else again.
