### PR TITLE
Add close all button for written options

### DIFF
--- a/src/components/pages/InitializeMarket.js
+++ b/src/components/pages/InitializeMarket.js
@@ -21,7 +21,7 @@ import useWallet from '../../hooks/useWallet'
 import useOptionsMarkets from '../../hooks/useOptionsMarkets'
 import useSerumMarketInfo from '../../hooks/useSerumMarketInfo'
 import { getStrikePrices } from '../../utils/getStrikePrices'
-import { getLastFridayOfMonths, getZeroDayExpiration } from '../../utils/dates'
+import { getLastFridayOfMonths } from '../../utils/dates'
 import useAssetList from '../../hooks/useAssetList'
 import { useOptionMarket } from '../../hooks/useOptionMarket'
 
@@ -31,8 +31,6 @@ import { ContractSizeSelector } from '../ContractSizeSelector'
 const darkBorder = `1px solid ${theme.palette.background.main}`
 
 const expirations = getLastFridayOfMonths(10)
-const zeroDay = getZeroDayExpiration()
-expirations.unshift(zeroDay)
 
 const InitializeMarket = () => {
   const { pushNotification } = useNotifications()

--- a/src/components/pages/Markets/Markets.js
+++ b/src/components/pages/Markets/Markets.js
@@ -9,7 +9,7 @@ import TableRow from '@material-ui/core/TableRow'
 import { withStyles } from '@material-ui/core/styles'
 
 import theme from '../../../utils/theme'
-import { getLastFridayOfMonths, getZeroDayExpiration } from '../../../utils/dates'
+import { getLastFridayOfMonths } from '../../../utils/dates'
 import { getStrikePrices, intervals } from '../../../utils/getStrikePrices'
 import { getPriceFromSerumOrderbook } from '../../../utils/orderbook'
 
@@ -102,8 +102,6 @@ const rowTemplate = {
 }
 
 const expirations = getLastFridayOfMonths(10)
-const zeroDay = getZeroDayExpiration()
-expirations.unshift(zeroDay)
 
 const USE_BONFIDA_MARK_PRICE = true
 

--- a/src/components/pages/OpenPositions/WrittenOptionsTable/WrittenOptionRow.js
+++ b/src/components/pages/OpenPositions/WrittenOptionsTable/WrittenOptionRow.js
@@ -98,7 +98,7 @@ export const WrittenOptionRow = ({
           label="Close"
           color="primary"
           variant="outlined"
-          onClick={closeOptionPostExpiration}
+          onClick={() => closeOptionPostExpiration()}
         />
         <Chip
           clickable
@@ -106,7 +106,9 @@ export const WrittenOptionRow = ({
           label="Close All"
           color="primary"
           variant="outlined"
-          onClick={closeOptionPostExpiration}
+          onClick={() => {
+            closeOptionPostExpiration(Math.min(ownedOptionTokenAccounts?.[0]?.amount, initialWriterTokenAccount.amount))
+          }}
         />
       </Box>
     )

--- a/src/hooks/useClosePosition.js
+++ b/src/hooks/useClosePosition.js
@@ -10,6 +10,12 @@ import { buildSolanaExplorerUrl } from '../utils/solanaExplorer'
 import { initializeTokenAccountTx, WRAPPED_SOL_ADDRESS } from '../utils/token'
 import { useSolanaMeta } from '../context/SolanaMetaContext'
 
+// Solana has a maximum packet size when sending a transaction.
+// As of writing 25 mints is a good round number that won't
+// breach that limit when OptionToken and WriterToken accounts
+// are included in TX.
+const maxClosesPerTx = 25
+
 /**
  * Close the Option the wallet has written in order to return the
  * underlying asset to the option writer
@@ -19,12 +25,6 @@ import { useSolanaMeta } from '../context/SolanaMetaContext'
  * @param underlyingAssetDestKEy PublicKey where the unlocked underlying asset will be sent
  * @param writerTokenSourceKey PublicKey of the address where the Writer Token will be burned from
  */
-
-// Solana has a maximum packet size when sending a transaction.
-// As of writing 25 mints is a good round number that won't
-// breach that limit when OptionToken and WriterToken accounts
-// are included in TX.
-const maxClosesPerTx = 25
 
 export const useClosePosition = (
   market,

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -11,7 +11,4 @@ export const getLastFridayOfMonths = (n = 10) =>
       return lastFriday
     })
     .filter((date) => date.isSameOrAfter(moment.utc()))
-
-export const getZeroDayExpiration = () => {
-  return moment.utc().add(30, 'minutes')
-}
+    


### PR DESCRIPTION
https://github.com/mithraiclabs/solana-options-frontend/issues/289

Buttons added for close all for both regular closePosition and  post-expiration, functionality maybe I can add a loop to close all based on market.size within WrittenOptionRow