### PR TITLE
Fix OI not showing for puts by changing how option market keys work.

### DIFF
--- a/src/components/pages/Markets/CallPutRow.js
+++ b/src/components/pages/Markets/CallPutRow.js
@@ -80,14 +80,16 @@ const CallPutRow = ({
     uAssetSymbol: uAsset?.tokenSymbol,
     qAssetSymbol: qAsset?.tokenSymbol,
     size: row.call?.size,
-    price: row.strike,
+    amountPerContract: row.call?.amountPerContract,
+    quoteAmountPerContract: row.call?.quoteAmountPerContract,
   })
   const putMarket = useOptionMarket({
     date: date.unix(),
     uAssetSymbol: qAsset?.tokenSymbol,
     qAssetSymbol: uAsset?.tokenSymbol,
     size: row.put?.size,
-    price: 1 / row.strike,
+    amountPerContract: row.put?.amountPerContract,
+    quoteAmountPerContract: row.put?.quoteAmountPerContract,
   })
   const callOptionMintInfo = useSPLTokenMintInfo(callMarket?.optionMintKey)
   const putOptionMintInfo = useSPLTokenMintInfo(putMarket?.optionMintKey)

--- a/src/hooks/useOptionMarket.ts
+++ b/src/hooks/useOptionMarket.ts
@@ -1,3 +1,5 @@
+import type BigNumber from 'bignumber.js'
+
 import { useMemo } from 'react'
 import { OptionMarket } from '../types'
 import useOptionsMarkets from './useOptionsMarkets'
@@ -7,18 +9,35 @@ export const useOptionMarket = ({
   qAssetSymbol,
   date,
   size,
-  price,
+  amountPerContract,
+  quoteAmountPerContract,
 }: {
   uAssetSymbol: string
   qAssetSymbol: string
   date: string
   size: number
-  price: number
+  amountPerContract: BigNumber
+  quoteAmountPerContract: BigNumber
 }): OptionMarket | undefined => {
   const { markets } = useOptionsMarkets()
 
   return useMemo(
-    () => markets[`${date}-${uAssetSymbol}-${qAssetSymbol}-${size}-${price}`],
-    [date, markets, price, qAssetSymbol, size, uAssetSymbol],
+    () =>
+      amountPerContract &&
+      quoteAmountPerContract &&
+      markets[
+        `${date}-${uAssetSymbol}-${qAssetSymbol}-${size}-${amountPerContract.toString(
+          10,
+        )}/${quoteAmountPerContract.toString(10)}`
+      ],
+    [
+      date,
+      markets,
+      qAssetSymbol,
+      size,
+      uAssetSymbol,
+      amountPerContract,
+      quoteAmountPerContract,
+    ],
   )
 }

--- a/src/hooks/useOptionsMarkets.js
+++ b/src/hooks/useOptionsMarkets.js
@@ -118,7 +118,10 @@ const useOptionsMarkets = () => {
 
         const key = `${newMarket.expiration}-${newMarket.uAssetSymbol}-${
           newMarket.qAssetSymbol
-        }-${newMarket.size}-${strike.toString(10)}`
+        }-${newMarket.size}-${amountPerContract.toString(
+          10,
+        )}/${quoteAmountPerContract.toString(10)}`
+
         newMarkets[key] = newMarket
       })
       // Not sure if we should replace the existing markets or merge them
@@ -253,8 +256,6 @@ const useOptionsMarkets = () => {
     }
     return []
   }
-
-  const getMyMarkets = () => Object.values(markets).filter((m) => m.createdByMe)
 
   const mint = async ({
     marketData,
@@ -401,7 +402,6 @@ const useOptionsMarkets = () => {
     getStrikePrices,
     getSizes,
     getDates,
-    getMyMarkets,
     mint,
     createAccountsAndMint,
     fetchMarketData,


### PR DESCRIPTION
OI was not showing up because we were still using the strike price to find the corresponding market from the option markets context, which doesn't always work in the case of puts due to them often being repeating decimals or otherwise suffering floating point precision issues. So changing the keys for the markets context object to also use the fractions instead of the strike price.

I _think_ all the components we still use are working fine with this, but not 100%. I do know the "mint" page is not fully working with this change, it's kind of a chore to get it working again, does anyone still use that page? I know it's not in the nav anymore but if we wanna make sure it still works for whatever reason, I can update it... although it doesn't even support calls vs puts, so might wanna just rework it in a separate PR if we plan to keep it around.