### PR TITLE
Check for navigator.serviceWorker instead of erroring

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -26,7 +26,9 @@ if (process.env.NODE_ENV === 'production') {
 
 const run = async () => {
   try {
-    await navigator.serviceWorker.register('/rate-limited-fetch-worker.js')
+    if (navigator?.serviceWorker) {
+      await navigator.serviceWorker.register('/rate-limited-fetch-worker.js')
+    }
   } catch (err) {
     Sentry.captureException(err)
   }


### PR DESCRIPTION
This isn't really a bug, but these events were getting pushed to Sentry a bit, and we can't really do anything about it because it just means the browser didn't support service workers. I'd rather only push an error to sentry if the `register` function failed, the current way is kind of pushing "false positives".