### PR TITLE
use new solana devnet RPC url

### DIFF
--- a/scripts/crankSerumMarket.js
+++ b/scripts/crankSerumMarket.js
@@ -12,7 +12,7 @@ require('../src/config')
 const argv = require('minimist')(process.argv.slice(2));
 const fs = require('fs');
 
-const connection = new Connection('https://devnet.solana.com');
+const connection = new Connection('https://api.devnet.solana.com');
 const solanaConfig = getSolanaConfig();
 const keyBuffer = fs.readFileSync(solanaConfig.keypair_path);
 const wallet = new Account(JSON.parse(keyBuffer));

--- a/scripts/initializeSerumMarket.js
+++ b/scripts/initializeSerumMarket.js
@@ -30,7 +30,7 @@ const {
   const keyBuffer = fs.readFileSync(solanaConfig.keypair_path)
   const wallet = new Account(JSON.parse(keyBuffer))
 
-  const connection = new Connection('https://devnet.solana.com')
+  const connection = new Connection('https://api.devnet.solana.com')
   const splData = getAssetsByNetwork('Devnet');
   console.log('*** SPL Data = ', splData);
   const dexProgramId = getDexProgramKeyByNetwork('Devnet');

--- a/service-worker/rate-limited-fetch-worker.js
+++ b/service-worker/rate-limited-fetch-worker.js
@@ -24,7 +24,7 @@ const rateLimitedFetch = async (url, options = {}) => {
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url)
 
-  if (url.host === 'devnet.solana.com') {
+  if (url.host.endsWith('devnet.solana.com')) {
     event.respondWith(
       rateLimitedFetch(event.request).then((response) => {
         return response


### PR DESCRIPTION
Updates existing RPC urls to new format mentioned in Solana's discord today

https://discord.com/channels/428295358100013066/517163444747894795/842827041807400960

![Screenshot 2021-05-14 at 7 35 32 PM](https://user-images.githubusercontent.com/601961/118314107-9381be80-b4eb-11eb-80fc-4b064a80268b.png)

## Todo

- [ ] run locally to confirm everything still works
- [ ] see what needs to be done to reload the serviceworker