### PR TITLE
Change main font family to Roboto. Also increase font sizes in some places.

### DIFF
--- a/src/components/BuySellDialog/BuySellDialog.js
+++ b/src/components/BuySellDialog/BuySellDialog.js
@@ -450,6 +450,7 @@ const BuySellDialog = ({
                       style={{
                         marginRight: theme.spacing(2),
                         minWidth: '98px',
+                        fontSize: '14px',
                       }}
                     />
                   )
@@ -557,7 +558,7 @@ const BuySellDialog = ({
                   <Box
                     py={2}
                     borderTop={`1px solid ${bgLighterColor}`}
-                    fontSize={'10px'}
+                    fontSize={'14px'}
                   >
                     {`This is a ${
                       type === 'call' ? 'covered call' : 'secured put'

--- a/src/components/BuySellDialog/UnsettledFunds.tsx
+++ b/src/components/BuySellDialog/UnsettledFunds.tsx
@@ -46,7 +46,8 @@ export const UnsettledFunds: React.VFC<{
       <Box display="flex" flex="1" justifyContent="space-between" my={2}>
         <Box>Options: {unsettledFunds.baseFree.toString()}</Box>
         <Box>
-          {qAssetSymbol}: {valueUnsettled.dividedBy(10 ** qAssetDecimals).toString()}
+          {qAssetSymbol}:{' '}
+          {valueUnsettled.dividedBy(10 ** qAssetDecimals).toString()}
         </Box>
       </Box>
       <Button color="primary" onClick={settleFunds} variant="outlined">

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -12,7 +12,7 @@ const Footer = () => (
       display="flex"
       flexDirection="row"
       justifyContent="center"
-      fontSize={11}
+      fontSize={13}
     >
       <Box px={1}>made by mithraiclabs</Box>
       {' | '}
@@ -40,7 +40,7 @@ const Footer = () => (
     </Box>
     <Box
       py={1}
-      fontSize={12}
+      fontSize={13}
       display="flex"
       flexDirection={'row'}
       alignItems="center"

--- a/src/components/OpenOrders/OpenOrderStyles.tsx
+++ b/src/components/OpenOrders/OpenOrderStyles.tsx
@@ -6,7 +6,7 @@ export const TCell = withStyles({
   root: {
     padding: '8px 16px',
     whiteSpace: 'nowrap',
-    fontSize: '11px',
+    fontSize: '13px',
     border: 'none',
     height: '52px',
     background: (theme.palette.background as any).medium, // Todo fix this type
@@ -17,7 +17,7 @@ export const THeadCell = withStyles({
   root: {
     padding: '4px 16px',
     whiteSpace: 'nowrap',
-    fontSize: '11px',
+    fontSize: '13px',
     height: '48px',
     border: 'none',
   },

--- a/src/components/OrderBook.js
+++ b/src/components/OrderBook.js
@@ -20,7 +20,7 @@ const BidAskCell = withStyles({
   root: {
     padding: '2px 6px',
     borderRight: `1px solid ${bgLighterColor}`,
-    fontSize: '12px',
+    fontSize: '14px',
     '&:last-child': {
       borderRight: 'none',
     },
@@ -39,107 +39,109 @@ const orderBookPropTypes = {
   bids: propTypes.arrayOf(bidOrAskType),
   asks: propTypes.arrayOf(bidOrAskType),
   setLimitPrice: propTypes.func.isRequired,
-  setOrderSize: propTypes.func.isRequired
+  setOrderSize: propTypes.func.isRequired,
 }
 
-const OrderBook = memo(({ bids = [[]], asks = [[]], setLimitPrice, setOrderSize }) => {
-  // Maybe we should do this zipping of the bids/asks elsewhere
-  // Doing it here for quick and dirty solution, don't over-engineer right? :)
-  const rows = []
-  const minRows = 4
-  let i = 0
-  while (
-    rows.length < bids.length ||
-    rows.length < asks.length ||
-    rows.length < minRows
-  ) {
-    rows.push({ bid: bids[i] || {}, ask: asks[i] || {}, key: i })
-    i += 1
-  }
+const OrderBook = memo(
+  ({ bids = [[]], asks = [[]], setLimitPrice, setOrderSize }) => {
+    // Maybe we should do this zipping of the bids/asks elsewhere
+    // Doing it here for quick and dirty solution, don't over-engineer right? :)
+    const rows = []
+    const minRows = 4
+    let i = 0
+    while (
+      rows.length < bids.length ||
+      rows.length < asks.length ||
+      rows.length < minRows
+    ) {
+      rows.push({ bid: bids[i] || {}, ask: asks[i] || {}, key: i })
+      i += 1
+    }
 
-  const setPriceAndSize = bidAsk => {
-    if (bidAsk?.price) setLimitPrice(bidAsk.price)
-    if (bidAsk?.size) setOrderSize(bidAsk.size)
-  }
+    const setPriceAndSize = (bidAsk) => {
+      if (bidAsk?.price) setLimitPrice(bidAsk.price)
+      if (bidAsk?.size) setOrderSize(bidAsk.size)
+    }
 
-  return (
-    <>
-      <Box pb={2}>Order Book</Box>
-      <Box width="100%">
-        <Table>
-          <TableHead>
-            <TableRow style={topRowBorder}>
-              <BidAskCell
-                colSpan={2}
-                align="left"
-                style={{ ...centerBorder, fontSize: '16px' }}
-              >
-                Bids
-              </BidAskCell>
-              <BidAskCell
-                colSpan={2}
-                align="right"
-                style={{ fontSize: '16px' }}
-              >
-                Asks
-              </BidAskCell>
-            </TableRow>
-            <TableRow>
-              <BidAskCell width="25%">price</BidAskCell>
-              <BidAskCell width="25%" style={{ ...centerBorder }}>
-                size
-              </BidAskCell>
-              <BidAskCell width="25%" align="right">
-                size
-              </BidAskCell>
-              <BidAskCell width="25%" align="right">
-                price
-              </BidAskCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {rows.map(({ bid, ask, key }) => {
-              return (
-                <TableRow key={key}>
-                  <BidAskCell 
-                    onClick={() => setPriceAndSize(bid)}
-                    width="25%"
-                    style={{ color: successColor, cursor: 'pointer' }}
-                  >
-                    {bid?.price || '\u00A0'}
-                  </BidAskCell>
-                  <BidAskCell 
-                    onClick={() => setPriceAndSize(bid)}
-                    width="25%"
-                    style={{ ...centerBorder, cursor: 'pointer' }}
-                  >
-                    {bid?.size || '\u00A0'}
-                  </BidAskCell>
-                  <BidAskCell
-                    onClick={() => setPriceAndSize(ask)}
-                    width="25%"
-                    align="right"
-                    style={{ cursor: 'pointer' }}
-                  >
-                    {ask?.size || '\u00A0'}
-                  </BidAskCell>
-                  <BidAskCell
-                    width="25%"
-                    align="right"
-                    style={{ color: errorColor, cursor: 'pointer' }}
-                    onClick={() => setPriceAndSize(ask)}
-                  >
-                    {ask?.price || '\u00A0'}
-                  </BidAskCell>
-                </TableRow>
-              )
-            })}
-          </TableBody>
-        </Table>
-      </Box>
-    </>
-  )
-})
+    return (
+      <>
+        <Box pb={2}>Order Book</Box>
+        <Box width="100%">
+          <Table>
+            <TableHead>
+              <TableRow style={topRowBorder}>
+                <BidAskCell
+                  colSpan={2}
+                  align="left"
+                  style={{ ...centerBorder, fontSize: '16px' }}
+                >
+                  Bids
+                </BidAskCell>
+                <BidAskCell
+                  colSpan={2}
+                  align="right"
+                  style={{ fontSize: '16px' }}
+                >
+                  Asks
+                </BidAskCell>
+              </TableRow>
+              <TableRow>
+                <BidAskCell width="25%">price</BidAskCell>
+                <BidAskCell width="25%" style={{ ...centerBorder }}>
+                  size
+                </BidAskCell>
+                <BidAskCell width="25%" align="right">
+                  size
+                </BidAskCell>
+                <BidAskCell width="25%" align="right">
+                  price
+                </BidAskCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rows.map(({ bid, ask, key }) => {
+                return (
+                  <TableRow key={key}>
+                    <BidAskCell
+                      onClick={() => setPriceAndSize(bid)}
+                      width="25%"
+                      style={{ color: successColor, cursor: 'pointer' }}
+                    >
+                      {bid?.price || '\u00A0'}
+                    </BidAskCell>
+                    <BidAskCell
+                      onClick={() => setPriceAndSize(bid)}
+                      width="25%"
+                      style={{ ...centerBorder, cursor: 'pointer' }}
+                    >
+                      {bid?.size || '\u00A0'}
+                    </BidAskCell>
+                    <BidAskCell
+                      onClick={() => setPriceAndSize(ask)}
+                      width="25%"
+                      align="right"
+                      style={{ cursor: 'pointer' }}
+                    >
+                      {ask?.size || '\u00A0'}
+                    </BidAskCell>
+                    <BidAskCell
+                      width="25%"
+                      align="right"
+                      style={{ color: errorColor, cursor: 'pointer' }}
+                      onClick={() => setPriceAndSize(ask)}
+                    >
+                      {ask?.price || '\u00A0'}
+                    </BidAskCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+        </Box>
+      </>
+    )
+  },
+)
 
 OrderBook.propTypes = orderBookPropTypes
 

--- a/src/components/pages/Landing.js
+++ b/src/components/pages/Landing.js
@@ -104,9 +104,9 @@ const Landing = () => {
           <Box display="flex" flexDirection={['column', 'row', 'row']}>
             <LandingCard
               title={`${Object.keys(markets).length}`}
-              text={`options market${
+              text={`Options Market${
                 Object.keys(markets).length === 1 ? '' : 's'
-              } created`}
+              } Created`}
               button={
                 <Button
                   color="primary"
@@ -124,9 +124,9 @@ const Landing = () => {
             />
             <LandingCard
               title={`${Object.keys(positions).length}`}
-              text={`open position${
+              text={`Open Position${
                 Object.keys(positions).length === 1 ? '' : 's'
-              } in wallet`}
+              } in Wallet`}
               button={<WalletStatus />}
             />
           </Box>

--- a/src/components/pages/Markets/CallPutRow.js
+++ b/src/components/pages/Markets/CallPutRow.js
@@ -31,7 +31,7 @@ const TCell = withStyles({
   root: {
     padding: '8px',
     whiteSpace: 'nowrap',
-    fontSize: '11px',
+    fontSize: '13px',
     border: 'none',
     height: '52px',
     background: theme.palette.background.medium,
@@ -42,7 +42,7 @@ const TCellLoading = withStyles({
   root: {
     padding: '16px',
     whiteSpace: 'nowrap',
-    fontSize: '11px',
+    fontSize: '13px',
     height: '52px',
     border: 'none',
     background: theme.palette.background.medium,
@@ -50,6 +50,10 @@ const TCellLoading = withStyles({
 })(TableCell)
 
 const darkBorder = `1px solid ${theme.palette.background.main}`
+
+const Empty = ({ children }) => (
+  <span style={{ opacity: '0.3' }}>{children}</span>
+)
 
 const CallPutRow = ({
   row,
@@ -128,8 +132,8 @@ const CallPutRow = ({
   const [loading, setLoading] = useState({ call: false, put: false })
 
   const formatStrike = (sp) => {
-    if (!sp) return '—'
-    return round ? sp.toFixed(precision) : sp.toString(10)
+    if (!sp) return <Empty>{'—'}</Empty>
+    return <span>{round ? sp.toFixed(precision) : sp.toString(10)}</span>
   }
 
   const handleInitialize = useCallback(
@@ -186,7 +190,7 @@ const CallPutRow = ({
     <TableRow hover role="checkbox" tabIndex={-1}>
       <TCell align="left" style={callCellStyle}>
         {row.call?.emptyRow ? (
-          '—'
+          ''
         ) : loading.call ? (
           <CircularProgress size={32} />
         ) : !connected ? (
@@ -222,7 +226,11 @@ const CallPutRow = ({
         )}
       </TCell>
       <TCell align="left" style={callCellStyle}>
-        {row.call?.size ? `${row.call.size} ${uAsset?.tokenSymbol || ''}` : '—'}
+        {row.call?.size ? (
+          `${row.call.size} ${uAsset?.tokenSymbol || ''}`
+        ) : (
+          <Empty>{'—'}</Empty>
+        )}
       </TCell>
       {row.call?.serumKey && serumMarkets[row.call?.serumKey]?.loading ? (
         <TCellLoading colSpan={6} style={callCellStyle}>
@@ -231,22 +239,24 @@ const CallPutRow = ({
       ) : (
         <>
           <TCell align="left" style={callCellStyle}>
-            {callHighestBid || '—'}
+            {callHighestBid || <Empty>{'—'}</Empty>}
           </TCell>
           <TCell align="left" style={callCellStyle}>
-            {callLowestAsk || '—'}
+            {callLowestAsk || <Empty>{'—'}</Empty>}
           </TCell>
           <TCell align="left" style={callCellStyle}>
-            {row.call?.change || '—'}
+            {row.call?.change || <Empty>{'—'}</Empty>}
           </TCell>
           <TCell align="left" style={callCellStyle}>
-            {row.call?.volume || '—'}
+            {row.call?.volume || <Empty>{'—'}</Empty>}
           </TCell>
           <TCell align="left" style={callCellStyle}>
-            {(callImpliedVol && `${callImpliedVol.toFixed(1)}%`) || '—'}
+            {(callImpliedVol && `${callImpliedVol.toFixed(1)}%`) || (
+              <Empty>{'—'}</Empty>
+            )}
           </TCell>
           <TCell align="left" style={callCellStyle}>
-            {callOptionMintInfo?.supply.toString() || '—'}
+            {callOptionMintInfo?.supply.toString() || <Empty>{'—'}</Empty>}
           </TCell>
         </>
       )}
@@ -259,11 +269,17 @@ const CallPutRow = ({
           background: theme.palette.background.main,
         }}
       >
-        <h4 style={{ margin: 0 }}>{formatStrike(row.strike, precision)}</h4>
+        <h4 style={{ margin: 0, fontFamily: 'JetBrains Mono' }}>
+          {formatStrike(row.strike, precision)}
+        </h4>
       </TCell>
 
       <TCell align="right" style={putCellStyle}>
-        {row.put?.size ? `${row.put.size} ${qAsset?.tokenSymbol || ''}` : '—'}
+        {row.put?.size ? (
+          `${row.put.size} ${qAsset?.tokenSymbol || ''}`
+        ) : (
+          <Empty>{'—'}</Empty>
+        )}
       </TCell>
       {row.put?.serumKey && serumMarkets[row.put?.serumKey]?.loading ? (
         <TCellLoading colSpan={6} style={putCellStyle}>
@@ -272,28 +288,30 @@ const CallPutRow = ({
       ) : (
         <>
           <TCell align="right" style={putCellStyle}>
-            {putHighestBid || '—'}
+            {putHighestBid || <Empty>{'—'}</Empty>}
           </TCell>
           <TCell align="right" style={putCellStyle}>
-            {putLowestAsk || '—'}
+            {putLowestAsk || <Empty>{'—'}</Empty>}
           </TCell>
           <TCell align="right" style={putCellStyle}>
-            {row.put?.change || '—'}
+            {row.put?.change || <Empty>{'—'}</Empty>}
           </TCell>
           <TCell align="right" style={putCellStyle}>
-            {row.put?.volume || '—'}
+            {row.put?.volume || <Empty>{'—'}</Empty>}
           </TCell>
           <TCell align="right" style={putCellStyle}>
-            {(putImpliedVol && `${putImpliedVol.toFixed(1)}%`) || '—'}
+            {(putImpliedVol && `${putImpliedVol.toFixed(1)}%`) || (
+              <Empty>{'—'}</Empty>
+            )}
           </TCell>
           <TCell align="right" style={putCellStyle}>
-            {putOptionMintInfo?.supply.toString() || '—'}
+            {putOptionMintInfo?.supply.toString() || <Empty>{'—'}</Empty>}
           </TCell>
         </>
       )}
       <TCell align="right" style={putCellStyle}>
         {row.put?.emptyRow ? (
-          '—'
+          ''
         ) : loading.put ? (
           <CircularProgress size={32} />
         ) : !connected ? (

--- a/src/components/pages/Markets/Markets.js
+++ b/src/components/pages/Markets/Markets.js
@@ -39,7 +39,7 @@ const THeadCell = withStyles({
   root: {
     padding: '4px',
     whiteSpace: 'nowrap',
-    fontSize: '11px',
+    fontSize: '13px',
     height: '48px',
     border: 'none',
   },
@@ -49,7 +49,7 @@ const THeadCellStrike = withStyles({
   root: {
     padding: '4px',
     whiteSpace: 'nowrap',
-    fontSize: '11px',
+    fontSize: '13px',
     height: '48px',
     border: 'none',
   },
@@ -59,7 +59,6 @@ const TCellLoading = withStyles({
   root: {
     padding: '16px',
     whiteSpace: 'nowrap',
-    fontSize: '11px',
     height: '52px',
     border: 'none',
   },
@@ -69,7 +68,7 @@ const TCellStrike = withStyles({
   root: {
     padding: '16px',
     whiteSpace: 'nowrap',
-    fontSize: '11px',
+    fontSize: '13px',
     height: '52px',
     border: 'none',
     background: theme.palette.background.default,
@@ -301,7 +300,7 @@ const Markets = () => {
             </Box>
           </Box>
           <Box px={[1, 1, 0]} py={[2, 2, 1]} width={['100%', '100%', 'auto']}>
-            <Box pb={'6px'} pl="10px" fontSize={'11px'}>
+            <Box pb={'6px'} pl="10px" fontSize={'13px'}>
               Asset Pair:
             </Box>
             <Box
@@ -455,7 +454,7 @@ const Markets = () => {
                 />
               }
               label={
-                <span style={{ fontSize: '11px' }}>Round Strike Prices</span>
+                <span style={{ fontSize: '13px' }}>Round Strike Prices</span>
               }
               style={{ margin: '0' }}
             />

--- a/src/components/pages/OpenPositions/WrittenOptionsTable/WrittenOptionRow.js
+++ b/src/components/pages/OpenPositions/WrittenOptionsTable/WrittenOptionRow.js
@@ -107,7 +107,12 @@ export const WrittenOptionRow = ({
           color="primary"
           variant="outlined"
           onClick={() => {
-            closeOptionPostExpiration(Math.min(ownedOptionTokenAccounts?.[0]?.amount, initialWriterTokenAccount.amount))
+            closeOptionPostExpiration(
+              Math.min(
+                ownedOptionTokenAccounts?.[0]?.amount,
+                initialWriterTokenAccount.amount,
+              ),
+            )
           }}
         />
       </Box>
@@ -132,7 +137,12 @@ export const WrittenOptionRow = ({
               color="primary"
               variant="outlined"
               onClick={() => {
-                closePosition(Math.min(ownedOptionTokenAccounts?.[0]?.amount, initialWriterTokenAccount.amount))
+                closePosition(
+                  Math.min(
+                    ownedOptionTokenAccounts?.[0]?.amount,
+                    initialWriterTokenAccount.amount,
+                  ),
+                )
               }}
             />
           </div>
@@ -161,7 +171,9 @@ export const WrittenOptionRow = ({
         {market.size} {market.uAssetSymbol}
       </TableCell>
       <TableCell width="7.5%">{initialWriterTokenAccount.amount}</TableCell>
-      <TableCell width="7.5%">{ownedOptionTokenAccounts?.[0]?.amount}</TableCell>
+      <TableCell width="7.5%">
+        {ownedOptionTokenAccounts?.[0]?.amount}
+      </TableCell>
       <TableCell width="20%">
         {formatExpirationTimestamp(market.expiration)}
       </TableCell>

--- a/src/components/server/template.js
+++ b/src/components/server/template.js
@@ -17,9 +17,10 @@ const baseCss = `
 
   body {
     background-color: ${theme.palette.background.main};
-    color: ${theme.palette.primary.main};
-    font-family: JetBrains Mono, monospace;
-    font-size: 14px;
+    color: ${theme.palette.text.primary};
+    font-family: Roboto, sans-serif;
+    font-size: 15px;
+    letter-spacing: 0.6;
   }
   
   h1, h2, h3 {
@@ -82,13 +83,18 @@ const Template = ({
       <link rel="icon" type="image/png" href={favicon} />
       <link rel="preconnect" href="https://fonts.gstatic.com" />
       <link
-        href="https://fonts.googleapis.com/css2?family=Goldman:wght@400;700&display=swap"
+        href="https://fonts.googleapis.com/css2?family=Goldman:wght@400&display=swap"
         rel="stylesheet"
       />
       <link
         href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300&family=Major+Mono+Display&display=swap"
         rel="stylesheet"
       />
+      <link
+        href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap"
+        rel="stylesheet"
+      />
+
       <style>{baseCss}</style>
       <style>{cssString}</style>
     </head>

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -11,7 +11,7 @@ const theme = createMuiTheme({
   },
   glow: '0px 0px 20px #1D4DC9',
   typography: {
-    fontFamily: 'JetBrains Mono, monospace',
+    fontFamily: 'Roboto, sans-serif',
   },
   palette: {
     type: 'dark',
@@ -60,7 +60,7 @@ const theme = createMuiTheme({
       main: '#373B40',
     },
     text: {
-      primary: '#8BEAFF',
+      primary: 'rgba(139, 234, 255, 0.9)',
     },
     // Used by `getContrastText()` to maximize the contrast between
     // the background and the text.


### PR DESCRIPTION
Changes:
- Make primary font Roboto. This is a Sans-serif font instead of monospace font so it should be a little clearer to read. The only place I kept the monospace font was on the strike price column because it keeps a bit of the a terminal looking style for flavor.
- I reduced the opacity of the dash on cells in the markets page that have no value, I think this makes the markets page a lot cleaner looking
- I increased the font size in several places by 2 pixels, which I think is better but we can probably still go up 1 more in many places.

I won't merge this until we have an agreement with the designers that this is the font we want to use as the main font, but i'm voting for this one. Other contenders so far: DM Sans

Some screenshots with before/after comparisons since this is a big change:
![Screen Shot 2021-05-15 at 6 29 20 PM](https://user-images.githubusercontent.com/9023427/118380249-4155a180-b5ae-11eb-9fe8-a571c604d437.png)
![Roboto](https://user-images.githubusercontent.com/9023427/118380251-431f6500-b5ae-11eb-98e5-c42f3750e942.png)


![Screen Shot 2021-05-15 at 6 29 06 PM](https://user-images.githubusercontent.com/9023427/118380256-4ca8cd00-b5ae-11eb-899b-0f69d515f1e7.png)
![Screen Shot 2021-05-15 at 6 29 11 PM](https://user-images.githubusercontent.com/9023427/118380257-4f0b2700-b5ae-11eb-83ee-cb63aa08fd16.png)

