### PR TITLE
Show all strikes again -- Kind of...

### DIFF
--- a/src/components/pages/Markets/Markets.js
+++ b/src/components/pages/Markets/Markets.js
@@ -120,7 +120,7 @@ const Markets = () => {
   const [round, setRound] = useState(true)
   const [buySellDialogOpen, setBuySellDialogOpen] = useState(false)
   const [callPutData, setCallPutData] = useState({ type: 'call' })
-  const [showAllStrikes] = useState(false) // TODO: let user configure this
+  const [showAllStrikes] = useState(true) // TODO: let user configure this
 
   // Unfortunately we need to set contract size in a useEffect because uAsset is asynchronously loaded
   useEffect(() => {


### PR DESCRIPTION
I noticed that several strikes started disappearing from the page as the real market price of BTC went down a bit, which made them inaccessible from the UI. It was not possible to interact with orders you had placed in those markets before the price went down, so I think we need to switch the "showAllStrikes" back to true. 

However, this doesn't mean tons of random strike prices that don't match each other will show up. The strikes that are displayed are still filtered by our set of hard coded intervals here: https://github.com/mithraiclabs/psyoptions-frontend/blob/master/src/utils/getStrikePrices.js

I think this is actually the way to go anyway. Seems like Deribit and probably other places manually set the strikes for a certain expiration. As long as our initialize page is not easily accessible to the public, and we only show strikes that match one of the intervals in that util function, I think that fixes about 99% of the issues we had initially with weird strikes.

If it becomes an issue again we can always revisit this feature.

Example before and after (Was testing on another branch so you get to see some other cool stuff, not part of this PR):
![Screen Shot 2021-05-15 at 10 34 42 PM](https://user-images.githubusercontent.com/9023427/118384050-2cd6d080-b5d1-11eb-9524-2b6702eb0af6.png)
![Screen Shot 2021-05-15 at 10 54 53 PM](https://user-images.githubusercontent.com/9023427/118384054-2f392a80-b5d1-11eb-9fdd-6d7c8f78052b.png)
