### PR TITLE
Fix flipped decimals for puts being passed into buy/sell dialog

### DIFF
--- a/src/components/BuySellDialog/BuySellDialog.js
+++ b/src/components/BuySellDialog/BuySellDialog.js
@@ -541,13 +541,17 @@ const BuySellDialog = ({
                           <BuyButton
                             parsedLimitPrice={parsedLimitPrice}
                             numberOfAsks={orderbook?.asks?.length || 0}
-                            qAssetSymbol={qAssetSymbol}
                             orderType={orderType}
                             orderCost={parsedLimitPrice.multipliedBy(
                               parsedOrderSize,
                             )}
                             parsedOrderSize={parsedOrderSize}
-                            qAssetBalance={qAssetBalance}
+                            qAssetSymbol={
+                              type === 'put' ? uAssetSymbol : qAssetSymbol
+                            }
+                            qAssetBalance={
+                              type === 'put' ? uAssetBalance : qAssetBalance
+                            }
                             onClick={handleBuyOrder}
                           />
                         </Box>

--- a/src/components/pages/Markets/Markets.js
+++ b/src/components/pages/Markets/Markets.js
@@ -253,9 +253,13 @@ const Markets = () => {
         onClose={() => setBuySellDialogOpen(false)}
         round={round}
         precision={precision}
-        uAssetDecimals={uAsset?.decimals || 0}
-        qAssetDecimals={qAsset?.decimals || 0}
         date={date}
+        uAssetDecimals={
+          callPutData?.type === 'call' ? uAsset?.decimals : qAsset?.decimals
+        }
+        qAssetDecimals={
+          callPutData?.type === 'call' ? qAsset?.decimals : uAsset?.decimals
+        }
       />
       <Box
         display="flex"


### PR DESCRIPTION
The buy/sell dialog needs to have the underlying and quote decimals reversed for the puts, which we weren't doing when passing props to it. This must have slipped by before because all the assets previously had the same amount of decimals.

The better long term solution would probably be to store the underlying and quote decimals in the markets objects as well as the other values there, and always get the information from there instead of from the assets that are currently selected for display. It's just a bit more complicated to do so I wanted to leave it for now.

Also noticed the buy button tooltip for puts was showing the wrong balance so I fixed that as well.