### PR TITLE
Store expiration date offline and move it to context

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -1,5 +1,11 @@
 import React from 'react'
-import { FormControl, InputLabel, Select, MenuItem } from '@material-ui/core'
+import {
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  NoSsr,
+} from '@material-ui/core'
 
 const Sel = (props) => {
   const { disabled, label, value, onChange, options } = props
@@ -15,7 +21,7 @@ const Sel = (props) => {
         {options
           ? options.map((option) => (
               <MenuItem key={option.text} value={option.value}>
-                {option.text}
+                <NoSsr>{option.text}</NoSsr>
               </MenuItem>
             ))
           : null}

--- a/src/components/pages/Markets/Markets.js
+++ b/src/components/pages/Markets/Markets.js
@@ -7,9 +7,9 @@ import TableContainer from '@material-ui/core/TableContainer'
 import TableHead from '@material-ui/core/TableHead'
 import TableRow from '@material-ui/core/TableRow'
 import { withStyles } from '@material-ui/core/styles'
+import moment from 'moment'
 
 import theme from '../../../utils/theme'
-import { getLastFridayOfMonths } from '../../../utils/dates'
 import { getStrikePrices, intervals } from '../../../utils/getStrikePrices'
 import { getPriceFromSerumOrderbook } from '../../../utils/orderbook'
 
@@ -22,6 +22,7 @@ import {
   useSerumOrderbook,
   useSubscribeSerumOrderbook,
 } from '../../../hooks/Serum'
+import useExpirationDate from '../../../hooks/useExpirationDate'
 
 import Page from '../Page'
 import Select from '../../Select'
@@ -100,8 +101,6 @@ const rowTemplate = {
   },
 }
 
-const expirations = getLastFridayOfMonths(10)
-
 const USE_BONFIDA_MARK_PRICE = true
 
 const defaultContractSizes = {
@@ -111,7 +110,7 @@ const defaultContractSizes = {
 
 const Markets = () => {
   const { uAsset, qAsset, setUAsset, assetListLoading } = useAssetList()
-  const [date, setDate] = useState(expirations[0])
+  const { selectedDate: date, setSelectedDate, dates } = useExpirationDate()
   const [contractSize, setContractSize] = useState(100)
   const { chain, buildOptionsChain } = useOptionsChain()
   const { marketsLoading, fetchMarketData } = useOptionsMarkets()
@@ -285,10 +284,10 @@ const Markets = () => {
               <Select
                 variant="filled"
                 label="Expiration Date"
-                value={date}
-                onChange={(e) => setDate(e.target.value)}
-                options={expirations.map((d) => ({
-                  value: d,
+                value={date.toISOString()}
+                onChange={(e) => setSelectedDate(moment.utc(e.target.value))}
+                options={dates.map((d) => ({
+                  value: d.toISOString(),
                   text: `${d.format('ll')} | 23:59:59 UTC`,
                 }))}
                 style={{

--- a/src/context/ExpirationDateContext.tsx
+++ b/src/context/ExpirationDateContext.tsx
@@ -1,0 +1,53 @@
+import type { Moment } from 'moment'
+import moment from 'moment'
+import React, { createContext, useContext, useEffect } from 'react'
+import useLocalStorageState from 'use-local-storage-state'
+
+import { getLastFridayOfMonths } from '../utils/dates'
+
+type DateContextValue = {
+  dates: Moment[]
+  selectedDate: Moment | undefined
+  setSelectedDate: (date: Moment) => void
+}
+
+const dates = getLastFridayOfMonths(10)
+
+const ExpirationDateContext = createContext<DateContextValue>({
+  selectedDate: undefined,
+  dates,
+  setSelectedDate: () => {},
+})
+
+const defaultDate = dates[0].toISOString()
+
+const ExpirationDateProvider: React.FC = ({ children }) => {
+  const [_selectedDate, _setSelectedDate] = useLocalStorageState(
+    'selectedDate',
+    defaultDate,
+  )
+
+  const parsedDate = moment.utc(_selectedDate)
+
+  useEffect(() => {
+    if (parsedDate.isBefore(moment.utc())) {
+      _setSelectedDate(dates[0].toISOString())
+    }
+  }, [parsedDate, _setSelectedDate])
+
+  const value = {
+    dates,
+    selectedDate: parsedDate,
+    setSelectedDate: (date: Moment) => {
+      _setSelectedDate(date.toISOString())
+    },
+  }
+
+  return (
+    <ExpirationDateContext.Provider value={value}>
+      {children}
+    </ExpirationDateContext.Provider>
+  )
+}
+
+export { ExpirationDateContext, ExpirationDateProvider }

--- a/src/context/store.js
+++ b/src/context/store.js
@@ -16,6 +16,7 @@ import theme from '../utils/theme'
 import { SerumOrderbooksProvider } from './SerumOrderbookContext'
 import { SPLTokenMintsProvider } from './SPLTokenMintsContext'
 import { SerumOpenOrdersProvider } from './SerumOpenOrdersContext'
+import { ExpirationDateProvider } from './ExpirationDateContext'
 
 const _providers = [
   // eslint-disable-next-line react/no-children-prop
@@ -33,6 +34,7 @@ const _providers = [
   <SerumOrderbooksProvider />,
   <SerumOpenOrdersProvider />,
   <PasswordProvider />,
+  <ExpirationDateProvider />,
 ]
 
 // flatten context providers for simpler app component tree

--- a/src/hooks/useExpirationDate.js
+++ b/src/hooks/useExpirationDate.js
@@ -1,0 +1,6 @@
+import { useContext } from 'react'
+import { ExpirationDateContext } from '../context/ExpirationDateContext'
+
+const useExpirationDate = () => useContext(ExpirationDateContext)
+
+export default useExpirationDate

--- a/src/utils/networkInfo.js
+++ b/src/utils/networkInfo.js
@@ -100,8 +100,7 @@ const getAssetsByNetwork = (name) => {
           tokenSymbol: 'PSY',
           mintAddress: 'BzwRWwr1kCLJVUUM14fQthP6FJKrGpXjw3ZHTZ6PQsYa',
           tokenName: 'PSY Test',
-          icon:
-            'https://raw.githubusercontent.com/trustwallet/assets/08d734b5e6ec95227dc50efef3a9cdfea4c398a1/blockchains/ethereum/assets/0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984/logo.png',
+          icon: 'https://docs.psyoptions.io/img/PsyOps.svg',
         },
         {
           tokenSymbol: 'USDC',


### PR DESCRIPTION
For https://github.com/mithraiclabs/psyoptions-frontend/issues/230

Makes the selected expiration date stored in local storage. If you start the app and your locally stored date is before the earliest valid expiration date (i.e. in the past) then it _should_ choose the first valid one, haven't tested that part yet since it's a bit annoying to test

I also changed the PSY logo in the network info to pull our logo from the docs site