### PR TITLE
Small markets page design update before adding paging controls

### DIFF
--- a/src/components/OpenOrders/OpenOrderStyles.tsx
+++ b/src/components/OpenOrders/OpenOrderStyles.tsx
@@ -2,9 +2,11 @@ import TableCell from '@material-ui/core/TableCell'
 import { withStyles } from '@material-ui/core/styles'
 import theme from '../../utils/theme'
 
+const borderLight = `1px solid ${theme.palette.background.paper}`
+
 export const TCell = withStyles({
   root: {
-    padding: '8px 16px',
+    padding: '8px 12px',
     whiteSpace: 'nowrap',
     fontSize: '14px',
     border: 'none',
@@ -15,10 +17,13 @@ export const TCell = withStyles({
 
 export const THeadCell = withStyles({
   root: {
-    padding: '4px 16px',
+    padding: '4px 12px',
     whiteSpace: 'nowrap',
     fontSize: '14px',
     height: '48px',
     border: 'none',
+    borderTop: borderLight,
+    borderBottom: borderLight,
+    background: (theme.palette.background as any).medium,
   },
 })(TableCell)

--- a/src/components/OpenOrders/OpenOrders.tsx
+++ b/src/components/OpenOrders/OpenOrders.tsx
@@ -45,10 +45,11 @@ const OpenOrders: React.FC<{
       const fetchOpenOrders = async (key) => {
         const { serumMarket } = serumMarkets[key]
         if (serumMarket?.market) {
-          const orders = await serumMarket.market.findOpenOrdersAccountsForOwner(
-            connection,
-            pubKey,
-          )
+          const orders =
+            await serumMarket.market.findOpenOrdersAccountsForOwner(
+              connection,
+              pubKey,
+            )
           setOpenOrders((prevOpenOrders) => ({
             ...prevOpenOrders,
             [key]: {
@@ -79,15 +80,27 @@ const OpenOrders: React.FC<{
     }
   }, [connection, serumMarkets, wallet, pubKey, openOrders, setOpenOrders])
 
+  const openOrdersArray = optionMarkets
+    .map((optionMarket) => {
+      if (optionMarket?.serumKey) {
+        return optionMarket
+      }
+      return undefined
+    })
+    .filter((item) => !!item)
+
   return (
-    <Box>
+    <Box mt={'20px'}>
       <TableContainer>
         <Table stickyHeader aria-label="sticky table">
           <TableHead>
             <TableRow>
-              <TableCell colSpan={10}>
+              <THeadCell
+                colSpan={10}
+                style={{ borderTop: 'none', padding: '16px 20px' }}
+              >
                 <h3 style={{ margin: 0 }}>Open Orders</h3>
-              </TableCell>
+              </THeadCell>
             </TableRow>
             <TableRow>
               <THeadCell>Side</THeadCell>
@@ -112,17 +125,12 @@ const OpenOrders: React.FC<{
                 </TCell>
               </TableRow>
             ) : (
-              optionMarkets.map((optionMarket) => {
-                if (optionMarket?.serumKey) {
-                  return (
-                    <OpenOrdersForMarket
-                      {...optionMarket}
-                      key={`${optionMarket.serumKey}`}
-                    />
-                  )
-                }
-                return null
-              })
+              openOrdersArray.map((optionMarket) => (
+                <OpenOrdersForMarket
+                  {...optionMarket}
+                  key={`${optionMarket.serumKey}`}
+                />
+              ))
             )}
           </TableBody>
         </Table>

--- a/src/components/pages/Markets/CallPutRow.js
+++ b/src/components/pages/Markets/CallPutRow.js
@@ -1,8 +1,7 @@
 import React, { useState, useCallback, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import TableRow from '@material-ui/core/TableRow'
-import TableCell from '@material-ui/core/TableCell'
-import { withStyles } from '@material-ui/core/styles'
+
 import CircularProgress from '@material-ui/core/CircularProgress'
 import Button from '@material-ui/core/Button'
 import moment from 'moment'
@@ -27,29 +26,7 @@ import { useOptionMarket } from '../../../hooks/useOptionMarket'
 import ConnectButton from '../../ConnectButton'
 import { useInitializeMarkets } from '../../../hooks/useInitializeMarkets'
 
-const TCell = withStyles({
-  root: {
-    padding: '8px',
-    whiteSpace: 'nowrap',
-    fontSize: '14px',
-    border: 'none',
-    height: '48px',
-    background: theme.palette.background.medium,
-  },
-})(TableCell)
-
-const TCellLoading = withStyles({
-  root: {
-    padding: '16px',
-    whiteSpace: 'nowrap',
-    fontSize: '14px',
-    height: '48px',
-    border: 'none',
-    background: theme.palette.background.medium,
-  },
-})(TableCell)
-
-const darkBorder = `1px solid ${theme.palette.background.main}`
+import { TCell, TCellLoading, TCellStrike } from './styles'
 
 const Empty = ({ children }) => (
   <span style={{ opacity: '0.3' }}>{children}</span>
@@ -198,10 +175,10 @@ const CallPutRow = ({
   )
 
   const callCellStyle = row.strike?.lte(markPrice)
-    ? { backgroundColor: theme.palette.background.light }
+    ? { backgroundColor: theme.palette.background.tableHighlight }
     : undefined
   const putCellStyle = row.strike?.gte(markPrice)
-    ? { backgroundColor: theme.palette.background.light }
+    ? { backgroundColor: theme.palette.background.tableHighlight }
     : undefined
 
   return (
@@ -281,20 +258,11 @@ const CallPutRow = ({
         </>
       )}
 
-      <TCell
-        align="center"
-        style={{
-          borderLeft: darkBorder,
-          borderRight: darkBorder,
-          background: theme.palette.background.main,
-          paddingLeft: '16px',
-          paddingRight: '16px',
-        }}
-      >
+      <TCellStrike align="center">
         <h4 style={{ margin: 0, fontWeight: 400 }}>
           {formatStrike(row.strike, precision)}
         </h4>
-      </TCell>
+      </TCellStrike>
 
       {row.put?.serumKey && serumMarkets[row.put?.serumKey]?.loading ? (
         <TCellLoading colSpan={7} style={putCellStyle}>

--- a/src/components/pages/Markets/Markets.js
+++ b/src/components/pages/Markets/Markets.js
@@ -4,11 +4,9 @@ import FormControlLabel from '@material-ui/core/FormControlLabel'
 import Switch from '@material-ui/core/Switch'
 import Table from '@material-ui/core/Table'
 import TableBody from '@material-ui/core/TableBody'
-import TableCell from '@material-ui/core/TableCell'
 import TableContainer from '@material-ui/core/TableContainer'
 import TableHead from '@material-ui/core/TableHead'
 import TableRow from '@material-ui/core/TableRow'
-import { withStyles } from '@material-ui/core/styles'
 import moment from 'moment'
 
 import theme from '../../../utils/theme'
@@ -32,51 +30,12 @@ import SelectAsset from '../../SelectAsset'
 import CallPutRow from './CallPutRow'
 import BuySellDialog from '../../BuySellDialog'
 import Loading from '../../Loading'
-import RefreshButton from '../../RefreshButton'
 import OpenOrders from '../../OpenOrders'
 import { ContractSizeSelector } from '../../ContractSizeSelector'
 
+import { TCellLoading, THeadCell, TCellStrike } from './styles'
+
 const dblsp = `${'\u00A0'}${'\u00A0'}`
-
-const THeadCell = withStyles({
-  root: {
-    padding: '4px',
-    whiteSpace: 'nowrap',
-    fontSize: '14px',
-    height: '48px',
-    border: 'none',
-  },
-})(TableCell)
-
-const THeadCellStrike = withStyles({
-  root: {
-    padding: '4px',
-    whiteSpace: 'nowrap',
-    fontSize: '14px',
-    height: '48px',
-    border: 'none',
-  },
-})(TableCell)
-
-const TCellLoading = withStyles({
-  root: {
-    padding: '16px',
-    whiteSpace: 'nowrap',
-    height: '48px',
-    border: 'none',
-  },
-})(TableCell)
-
-const TCellStrike = withStyles({
-  root: {
-    padding: '16px',
-    whiteSpace: 'nowrap',
-    fontSize: '14px',
-    height: '48px',
-    border: 'none',
-    background: theme.palette.background.default,
-  },
-})(TableCell)
 
 const rowTemplate = {
   call: {
@@ -115,7 +74,7 @@ const Markets = () => {
   const { selectedDate: date, setSelectedDate, dates } = useExpirationDate()
   const [contractSize, setContractSize] = useState(100)
   const { chain, buildOptionsChain } = useOptionsChain()
-  const { marketsLoading, fetchMarketData } = useOptionsMarkets()
+  const { marketsLoading } = useOptionsMarkets()
   const { serumMarkets, fetchSerumMarket } = useSerum()
   const [round, setRound] = useState(true)
   const [buySellDialogOpen, setBuySellDialogOpen] = useState(false)
@@ -215,7 +174,7 @@ const Markets = () => {
   useEffect(() => {
     // Load serum markets when the options chain changes
     // Only if they don't already exist for the matching call/put
-    chain.forEach(({ call, put }) => {
+    filteredChain.forEach(({ call, put }) => {
       if (call?.serumKey && !serumMarkets[call.serumKey]) {
         fetchSerumMarket(...call.serumKey.split('-'))
       }
@@ -223,7 +182,7 @@ const Markets = () => {
         fetchSerumMarket(...put.serumKey.split('-'))
       }
     })
-  }, [chain, fetchSerumMarket, serumMarkets])
+  }, [filteredChain, fetchSerumMarket, serumMarkets])
 
   // Open buy/sell/mint modal
   const handleBuySellClick = useCallback((callOrPut) => {
@@ -334,23 +293,14 @@ const Markets = () => {
           </Box>
         </Box>
         <Box position="relative">
-          <Box
-            position="absolute"
-            zIndex={5}
-            right={['16px', '16px', '1px']}
-            top={'8px'}
-            bgcolor={theme.palette.background.default}
-          >
-            <RefreshButton
-              loading={fullPageLoading}
-              onRefresh={fetchMarketData}
-            />
-          </Box>
           <TableContainer>
             <Table stickyHeader aria-label="sticky table">
               <TableHead>
                 <TableRow>
-                  <TableCell colSpan={8}>
+                  <THeadCell
+                    colSpan={8}
+                    style={{ borderTop: 'none', padding: '16px 20px' }}
+                  >
                     <h3 style={{ margin: 0 }}>
                       {`Calls${
                         uAsset && qAsset && !assetListLoading
@@ -358,9 +308,12 @@ const Markets = () => {
                           : ''
                       }`}
                     </h3>
-                  </TableCell>
-                  <TableCell colSpan={1} />
-                  <TableCell colSpan={8}>
+                  </THeadCell>
+                  <TCellStrike colSpan={1} />
+                  <THeadCell
+                    colSpan={8}
+                    style={{ borderTop: 'none', padding: '16px 20px' }}
+                  >
                     <h3 style={{ margin: 0 }}>
                       {`Puts${
                         uAsset && qAsset && !assetListLoading
@@ -368,10 +321,12 @@ const Markets = () => {
                           : ''
                       }`}
                     </h3>
-                  </TableCell>
+                  </THeadCell>
                 </TableRow>
                 <TableRow>
-                  <THeadCell align="left">Action</THeadCell>
+                  <THeadCell align="left" style={{ paddingLeft: '16px' }}>
+                    Action
+                  </THeadCell>
                   {/* <THeadCell align="left">Size</THeadCell> */}
                   <THeadCell align="left" width={'70px'}>
                     IV
@@ -389,7 +344,7 @@ const Markets = () => {
                   <THeadCell align="left">Volume</THeadCell>
                   <THeadCell align="left">Open</THeadCell>
 
-                  <THeadCellStrike align="center">Strike</THeadCellStrike>
+                  <TCellStrike align="center">Strike</TCellStrike>
 
                   {/* <THeadCell align="right">Size</THeadCell> */}
                   <THeadCell align="right" width={'70px'}>
@@ -407,7 +362,9 @@ const Markets = () => {
                   <THeadCell align="right">Change</THeadCell>
                   <THeadCell align="right">Volume</THeadCell>
                   <THeadCell align="right">Open</THeadCell>
-                  <THeadCell align="right">Action</THeadCell>
+                  <THeadCell align="right" style={{ paddingRight: '16px' }}>
+                    Action
+                  </THeadCell>
                 </TableRow>
               </TableHead>
               <TableBody>
@@ -447,41 +404,52 @@ const Markets = () => {
                     />
                   )
                 })}
+                <TableRow>
+                  <THeadCell colSpan={17} style={{ borderBottom: 'none' }}>
+                    <Box
+                      py={1}
+                      px={[1, 1, 0]}
+                      display="flex"
+                      justifyContent="space-between"
+                      alignItems="center"
+                    >
+                      <Box width="33%" align="left">
+                        {!!uAsset?.tokenSymbol && !!markPrice && (
+                          <>
+                            {uAsset?.tokenSymbol} Market Price: $
+                            {markPrice && markPrice.toFixed(precision)}
+                          </>
+                        )}
+                      </Box>
+                      <Box width="33%" align="center">
+                        {/* Paging Controls Go Here */}
+                      </Box>
+                      <Box width="33%" align="right">
+                        <FormControlLabel
+                          labelPlacement="start"
+                          control={
+                            <Switch
+                              checked={round}
+                              onChange={() => setRound(!round)}
+                              name="round-strike-prices"
+                              color="primary"
+                              size="small"
+                            />
+                          }
+                          label={
+                            <span style={{ fontSize: '14px' }}>
+                              Round Strike Prices
+                            </span>
+                          }
+                          style={{ margin: '0' }}
+                        />
+                      </Box>
+                    </Box>
+                  </THeadCell>
+                </TableRow>
               </TableBody>
             </Table>
           </TableContainer>
-          <Box
-            py={1}
-            px={[1, 1, 0]}
-            display="flex"
-            justifyContent="space-between"
-            alignItems="center"
-          >
-            <Box>
-              {!!uAsset?.tokenSymbol && !!markPrice && (
-                <>
-                  {uAsset?.tokenSymbol} Market Price: $
-                  {markPrice && markPrice.toFixed(precision)}
-                </>
-              )}
-            </Box>
-            <FormControlLabel
-              labelPlacement="start"
-              control={
-                <Switch
-                  checked={round}
-                  onChange={() => setRound(!round)}
-                  name="round-strike-prices"
-                  color="primary"
-                  size="small"
-                />
-              }
-              label={
-                <span style={{ fontSize: '14px' }}>Round Strike Prices</span>
-              }
-              style={{ margin: '0' }}
-            />
-          </Box>
           <Box>
             <OpenOrders optionMarkets={marketsFlat} />
           </Box>

--- a/src/components/pages/Markets/styles.js
+++ b/src/components/pages/Markets/styles.js
@@ -1,0 +1,66 @@
+import TableCell from '@material-ui/core/TableCell'
+import { withStyles } from '@material-ui/core/styles'
+import theme from '../../../utils/theme'
+
+const borderLight = `1px solid ${theme.palette.background.paper}`
+
+export const TCell = withStyles({
+  root: {
+    padding: '8px 12px',
+    whiteSpace: 'nowrap',
+    fontSize: '14px',
+    border: 'none',
+    height: '48px',
+    background: theme.palette.background.medium,
+  },
+})(TableCell)
+
+export const TCellLoading = withStyles({
+  root: {
+    padding: '8px 12px',
+    whiteSpace: 'nowrap',
+    fontSize: '14px',
+    height: '48px',
+    border: 'none',
+    background: theme.palette.background.medium,
+  },
+})(TableCell)
+
+export const THeadCell = withStyles({
+  root: {
+    padding: '4px 12px',
+    whiteSpace: 'nowrap',
+    fontSize: '14px',
+    height: '48px',
+    border: 'none',
+    borderTop: borderLight,
+    borderBottom: borderLight,
+    background: theme.palette.background.medium,
+  },
+})(TableCell)
+
+export const THeadCellStrike = withStyles({
+  root: {
+    padding: '4px 12px',
+    whiteSpace: 'nowrap',
+    fontSize: '14px',
+    height: '48px',
+    border: 'none',
+    borderTop: borderLight,
+    borderBottom: borderLight,
+    width: '130px',
+    background: theme.palette.background.medium,
+  },
+})(TableCell)
+
+export const TCellStrike = withStyles({
+  root: {
+    padding: '8px 12px',
+    whiteSpace: 'nowrap',
+    fontSize: '14px',
+    height: '48px',
+    border: 'none',
+    width: '130px',
+    background: theme.palette.background.paper,
+  },
+})(TableCell)

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -9,7 +9,7 @@ const theme = createMuiTheme({
     success: 'linear-gradient(90deg, #14758A 0%, #28C972 100%)',
     info: 'linear-gradient(90deg, #686775 0%, #9C9CB6 100%)',
   },
-  glow: '0px 0px 20px #1D4DC9',
+  glow: '0 2px 4px #000, 0 0px 12px #6dcbfd',
   typography: {
     fontFamily: 'Manrope, sans-serif',
     fontWeightRegular: 500,
@@ -52,9 +52,10 @@ const theme = createMuiTheme({
     },
     background: {
       lighter: '#5C585F',
-      light: '#36343E',
-      paper: '#36343E',
-      medium: '#2A2A34',
+      light: '#34343E',
+      paper: '#34343E',
+      tableHighlight: '#2A2A34',
+      medium: '#22222A',
       main: '#101017',
       default: '#101017',
     },


### PR DESCRIPTION
I implemented some of the design changes that Dave worked on for the markets page because I think the UI had to change a little in order for the paging controls (yet to be built) to make sense from a design perspective.

So the main changes are that the strike price column, table headers, and the smaller text at the bottom are all included with the main table background, making it feel like the whole table is one box. Also updated the header neon glow with a slight color change and a slight darker shadow under the text which Dave came up with to make the text pop out more / easier to read.

As you can see in this screenshot, the paging controls will end up being contained in that box on the bottom row, which I think will make more sense to the user. It makes it obvious that the pages are pages of this particular section of the UI:
![Screen Shot 2021-06-02 at 12 32 43 PM](https://user-images.githubusercontent.com/9023427/120520476-d542ae00-c3a1-11eb-8638-8af1153743ce.png)

