### PR TITLE
Convert buy/sell modal to typescript

### DIFF
--- a/src/components/BuySellDialog/SellButton.js
+++ b/src/components/BuySellDialog/SellButton.js
@@ -1,29 +1,7 @@
 import React from 'react'
-import { withStyles } from '@material-ui/core/styles'
-import Button from '@material-ui/core/Button'
 import Tooltip from '@material-ui/core/Tooltip'
-import theme from '../../utils/theme'
 
-const StyledSellButton = withStyles({
-  // The fakeDisabled prop is a hack/workaround
-  // to make the button look disabled but still show tooltips on hover
-  // Make sure to remove the onClick handler via props
-  root: ({ fakeDisabled }) =>
-    fakeDisabled
-      ? {
-          backgroundColor: theme.palette.error.dark,
-          color: 'rgba(255, 255, 255, 0.3)',
-          '&:hover': {
-            backgroundColor: theme.palette.error.dark,
-          },
-        }
-      : {
-          backgroundColor: theme.palette.error.main,
-          '&:hover': {
-            backgroundColor: theme.palette.error.light,
-          },
-        },
-})(Button)
+import { StyledSellButton } from './styles'
 
 const SellButton = ({
   amountPerContract,

--- a/src/components/BuySellDialog/styles.js
+++ b/src/components/BuySellDialog/styles.js
@@ -1,0 +1,50 @@
+import { withStyles } from '@material-ui/core/styles'
+import Button from '@material-ui/core/Button'
+import FilledInput from '@material-ui/core/FilledInput'
+import theme from '../../utils/theme'
+
+export const StyledFilledInput = withStyles({
+  root: {
+    borderRadius: 0,
+    width: '100%',
+    minWidth: '100px',
+  },
+  input: {
+    padding: '8px 12px !important',
+  },
+})(FilledInput)
+
+export const PlusMinusButton = withStyles({
+  root: {
+    borderRadius: 0,
+    minWidth: '38px',
+    backgroundColor: 'rgba(255, 255, 255, 0.09)',
+    marginLeft: '2px',
+    fontWeight: 700,
+    fontSize: '24px',
+    lineHeight: '24px',
+    '&:hover': {
+      backgroundColor: 'rgba(255, 255, 255, 0.18)',
+    },
+  },
+})(Button)
+export const StyledSellButton = withStyles({
+  // The fakeDisabled prop is a hack/workaround
+  // to make the button look disabled but still show tooltips on hover
+  // Make sure to remove the onClick handler via props
+  root: ({ fakeDisabled }) =>
+    fakeDisabled
+      ? {
+          backgroundColor: theme.palette.error.dark,
+          color: 'rgba(255, 255, 255, 0.3)',
+          '&:hover': {
+            backgroundColor: theme.palette.error.dark,
+          },
+        }
+      : {
+          backgroundColor: theme.palette.error.main,
+          '&:hover': {
+            backgroundColor: theme.palette.error.light,
+          },
+        },
+})(Button)

--- a/src/components/OrderBook.js
+++ b/src/components/OrderBook.js
@@ -41,109 +41,107 @@ const orderBookPropTypes = {
   setOrderSize: propTypes.func.isRequired,
 }
 
-const OrderBook = memo(
-  ({ bids = [[]], asks = [[]], setLimitPrice, setOrderSize }) => {
-    // Maybe we should do this zipping of the bids/asks elsewhere
-    // Doing it here for quick and dirty solution, don't over-engineer right? :)
-    const rows = []
-    const minRows = 4
-    // We can adjust the max rows as desired later
-    const maxRows = 8
-    let i = 0
-    while (
-      (rows.length < maxRows && rows.length < bids.length) ||
-      rows.length < asks.length ||
-      rows.length < minRows
-    ) {
-      rows.push({ bid: bids[i] || {}, ask: asks[i] || {}, key: i })
-      i += 1
-    }
+const OrderBook = ({ bids = [], asks = [], setLimitPrice, setOrderSize }) => {
+  // Maybe we should do this zipping of the bids/asks elsewhere
+  // Doing it here for quick and dirty solution, don't over-engineer right? :)
+  const rows = []
+  const minRows = 4
+  // We can adjust the max rows as desired later
+  const maxRows = 8
+  let i = 0
+  while (
+    (rows.length < maxRows && rows.length < bids.length) ||
+    rows.length < asks.length ||
+    rows.length < minRows
+  ) {
+    rows.push({ bid: bids[i] || {}, ask: asks[i] || {}, key: i })
+    i += 1
+  }
 
-    const setPriceAndSize = (bidAsk) => {
-      if (bidAsk?.price) setLimitPrice(bidAsk.price)
-      if (bidAsk?.size) setOrderSize(bidAsk.size)
-    }
+  const setPriceAndSize = (bidAsk) => {
+    if (bidAsk?.price) setLimitPrice(bidAsk.price)
+    if (bidAsk?.size) setOrderSize(bidAsk.size)
+  }
 
-    return (
-      <>
-        <Box pb={2}>Order Book</Box>
-        <Box width="100%">
-          <Table>
-            <TableHead>
-              <TableRow style={topRowBorder}>
-                <BidAskCell
-                  colSpan={2}
-                  align="left"
-                  style={{ ...centerBorder, fontSize: '16px' }}
-                >
-                  Bids
-                </BidAskCell>
-                <BidAskCell
-                  colSpan={2}
-                  align="right"
-                  style={{ fontSize: '16px' }}
-                >
-                  Asks
-                </BidAskCell>
-              </TableRow>
-              <TableRow>
-                <BidAskCell width="25%">price</BidAskCell>
-                <BidAskCell width="25%" style={{ ...centerBorder }}>
-                  size
-                </BidAskCell>
-                <BidAskCell width="25%" align="right">
-                  size
-                </BidAskCell>
-                <BidAskCell width="25%" align="right">
-                  price
-                </BidAskCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {rows.map(({ bid, ask, key }) => {
-                return (
-                  <TableRow key={key}>
-                    <BidAskCell
-                      onClick={() => setPriceAndSize(bid)}
-                      width="25%"
-                      style={{ color: successColor, cursor: 'pointer' }}
-                    >
-                      {bid?.price || '\u00A0'}
-                    </BidAskCell>
-                    <BidAskCell
-                      onClick={() => setPriceAndSize(bid)}
-                      width="25%"
-                      style={{ ...centerBorder, cursor: 'pointer' }}
-                    >
-                      {bid?.size || '\u00A0'}
-                    </BidAskCell>
-                    <BidAskCell
-                      onClick={() => setPriceAndSize(ask)}
-                      width="25%"
-                      align="right"
-                      style={{ cursor: 'pointer' }}
-                    >
-                      {ask?.size || '\u00A0'}
-                    </BidAskCell>
-                    <BidAskCell
-                      width="25%"
-                      align="right"
-                      style={{ color: errorColor, cursor: 'pointer' }}
-                      onClick={() => setPriceAndSize(ask)}
-                    >
-                      {ask?.price || '\u00A0'}
-                    </BidAskCell>
-                  </TableRow>
-                )
-              })}
-            </TableBody>
-          </Table>
-        </Box>
-      </>
-    )
-  },
-)
+  return (
+    <>
+      <Box pb={2}>Order Book</Box>
+      <Box width="100%">
+        <Table>
+          <TableHead>
+            <TableRow style={topRowBorder}>
+              <BidAskCell
+                colSpan={2}
+                align="left"
+                style={{ ...centerBorder, fontSize: '16px' }}
+              >
+                Bids
+              </BidAskCell>
+              <BidAskCell
+                colSpan={2}
+                align="right"
+                style={{ fontSize: '16px' }}
+              >
+                Asks
+              </BidAskCell>
+            </TableRow>
+            <TableRow>
+              <BidAskCell width="25%">price</BidAskCell>
+              <BidAskCell width="25%" style={{ ...centerBorder }}>
+                size
+              </BidAskCell>
+              <BidAskCell width="25%" align="right">
+                size
+              </BidAskCell>
+              <BidAskCell width="25%" align="right">
+                price
+              </BidAskCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map(({ bid, ask, key }) => {
+              return (
+                <TableRow key={key}>
+                  <BidAskCell
+                    onClick={() => setPriceAndSize(bid)}
+                    width="25%"
+                    style={{ color: successColor, cursor: 'pointer' }}
+                  >
+                    {bid?.price || '\u00A0'}
+                  </BidAskCell>
+                  <BidAskCell
+                    onClick={() => setPriceAndSize(bid)}
+                    width="25%"
+                    style={{ ...centerBorder, cursor: 'pointer' }}
+                  >
+                    {bid?.size || '\u00A0'}
+                  </BidAskCell>
+                  <BidAskCell
+                    onClick={() => setPriceAndSize(ask)}
+                    width="25%"
+                    align="right"
+                    style={{ cursor: 'pointer' }}
+                  >
+                    {ask?.size || '\u00A0'}
+                  </BidAskCell>
+                  <BidAskCell
+                    width="25%"
+                    align="right"
+                    style={{ color: errorColor, cursor: 'pointer' }}
+                    onClick={() => setPriceAndSize(ask)}
+                  >
+                    {ask?.price || '\u00A0'}
+                  </BidAskCell>
+                </TableRow>
+              )
+            })}
+          </TableBody>
+        </Table>
+      </Box>
+    </>
+  )
+}
 
 OrderBook.propTypes = orderBookPropTypes
 
-export default OrderBook
+export default memo(OrderBook)


### PR DESCRIPTION
Also moved the "styled" components to a separate file to de-clutter a little.

Really just want to close out https://github.com/mithraiclabs/psyoptions-frontend/issues/326

There might be more refactoring that _could_ be done here, but it should be better than when we initially opened that issue. We are now being consistent with all the types from the user input (handling converting the strings to numbers correctly etc), the buy/sell buttons have been moved out of the main component, some of the styled stuff has been moved out of the main component, and instead of using prop-types we're just using typescript types.