### PR TITLE
[feat] Add hover highlight to open order rows and written options

### DIFF
--- a/src/components/OpenOrders/OpenOrdersForMarket.tsx
+++ b/src/components/OpenOrders/OpenOrdersForMarket.tsx
@@ -68,7 +68,7 @@ const OpenOrdersForMarket: React.FC<{
     actualOpenOrders &&
     actualOpenOrders.map((order) => {
       return (
-        <TableRow key={`${JSON.stringify(order)}`}>
+        <TableRow hover key={`${JSON.stringify(order)}`}>
           <TCell>{order?.side}</TCell>
           <TCell>{type}</TCell>
           <TCell>{`${qAssetSymbol}/${uAssetSymbol}`}</TCell>

--- a/src/components/pages/OpenPositions/WrittenOptionsTable/WrittenOptionRow.js
+++ b/src/components/pages/OpenPositions/WrittenOptionsTable/WrittenOptionRow.js
@@ -173,7 +173,7 @@ export const WrittenOptionRow = React.memo(
     }
 
     return (
-      <TableRow key={marketKey}>
+      <TableRow hover key={marketKey}>
         <TableCell width="5%" />
         {/* <TableCell width="12%">Asset Pair</TableCell>
             <TableCell width="10%">Type</TableCell>


### PR DESCRIPTION
Keep congruence in styling updates across tables (currently open positions has hover highlight + https://github.com/mithraiclabs/psyoptions-frontend/pull/375 adds hover highlight to callputrows)

Also easier to distinguish between open order rows if lots open