### PR TITLE
Fix up OptionMarket type and its usage

### DIFF
--- a/src/components/BuySellDialog/BuySellDialog.tsx
+++ b/src/components/BuySellDialog/BuySellDialog.tsx
@@ -56,8 +56,8 @@ const BuySellDialog: React.VFC<{
   round: boolean
   precision: number
   type: string
-  optionMintAddress: string
-  writerTokenMintKey: string
+  optionMintKey: PublicKey
+  writerTokenMintKey: PublicKey
   serumKey: string
   date: Moment
   markPrice: number
@@ -77,7 +77,7 @@ const BuySellDialog: React.VFC<{
   round,
   precision,
   type,
-  optionMintAddress,
+  optionMintKey,
   writerTokenMintKey,
   serumKey,
   date,
@@ -108,8 +108,8 @@ const BuySellDialog: React.VFC<{
     quoteAmountPerContract,
   })
 
-  const optionAccounts = ownedTokenAccounts[optionMintAddress] || []
-  const writerAccounts = ownedTokenAccounts[writerTokenMintKey] || []
+  const optionAccounts = ownedTokenAccounts[`${optionMintKey}`] || []
+  const writerAccounts = ownedTokenAccounts[`${writerTokenMintKey}`] || []
   const uAssetAccounts = ownedTokenAccounts[uAssetMint] || []
   const qAssetAccounts = ownedTokenAccounts[qAssetMint] || []
 
@@ -182,7 +182,7 @@ const BuySellDialog: React.VFC<{
       const { tx1, tx2 } = await createInitializeMarketTx({
         connection,
         payer: pubKey,
-        baseMint: new PublicKey(optionMintAddress),
+        baseMint: optionMintKey,
         quoteMint:
           type === 'call'
             ? new PublicKey(qAssetMint)

--- a/src/components/pages/Mint.js
+++ b/src/components/pages/Mint.js
@@ -32,12 +32,8 @@ const expirations = getLastFridayOfMonths(10)
 const Mint = () => {
   const { pushNotification } = useNotifications()
   const { connected } = useWallet()
-  const {
-    getStrikePrices,
-    getSizes,
-    createAccountsAndMint,
-    fetchMarketData,
-  } = useOptionsMarkets()
+  const { getStrikePrices, getSizes, createAccountsAndMint, fetchMarketData } =
+    useOptionsMarkets()
   const { ownedTokenAccounts } = useOwnedTokenAccounts()
 
   const dates = expirations
@@ -69,7 +65,8 @@ const Mint = () => {
   )
   const ownedMintedOptionAccounts = useMemo(
     () =>
-      (marketData && ownedTokenAccounts[marketData.optionMintAddress]) || [],
+      (marketData && ownedTokenAccounts[marketData.optionMintKey.toString()]) ||
+      [],
     [marketData, ownedTokenAccounts],
   )
   const ownedWriterTokenMintAccounts = useMemo(

--- a/src/components/pages/OpenPositions/OpenPositions.js
+++ b/src/components/pages/OpenPositions/OpenPositions.js
@@ -44,13 +44,11 @@ const OpenPositions = () => {
       0,
     ),
     strikePrice: markets[key]?.strikePrice,
-    optionMarketKey: markets[key]?.optionMarketDataAddress,
     market: markets[key],
     qAssetMintAddress: markets[key]?.qAssetMint,
     uAssetMintAddress: markets[key]?.uAssetMint,
     qAssetSymbol: markets[key]?.qAssetSymbol,
     uAssetSymbol: markets[key]?.uAssetSymbol,
-    optionContractTokenKey: markets[key]?.optionMintAddress,
     amountPerContract: markets[key]?.amountPerContract,
     quoteAmountPerContract: markets[key]?.quoteAmountPerContract,
   }))
@@ -103,7 +101,10 @@ const OpenPositions = () => {
                   {positionRows
                     .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
                     .map((row) => (
-                      <PositionRow key={row.optionContractTokenKey} row={row} />
+                      <PositionRow
+                        key={row.market.optionMintKey.toString()}
+                        row={row}
+                      />
                     ))}
                 </TableBody>
               </Table>

--- a/src/components/pages/OpenPositions/PositionRow.tsx
+++ b/src/components/pages/OpenPositions/PositionRow.tsx
@@ -34,8 +34,6 @@ const PositionRow: React.VFC<{
     uAssetSymbol: string
     expiration: number
     market: OptionMarket
-    optionContractTokenKey: string
-    optionMarketKey: string
     size: number
     strikePrice: string
     uAssetMintAddress: string
@@ -84,7 +82,7 @@ const PositionRow: React.VFC<{
   const ownedQAssetKey = ownedTokenAccounts[row.qAssetMintAddress]?.[0]?.pubKey
   const ownedUAssetKey = ownedTokenAccounts[row.uAssetMintAddress]?.[0]?.pubKey
   const ownedOAssetKey =
-    ownedTokenAccounts[row.optionContractTokenKey]?.[0]?.pubKey
+    ownedTokenAccounts[row.market.optionMintKey.toString()]?.[0]?.pubKey
 
   const { exercise } = useExerciseOpenPosition(
     row.market,
@@ -113,7 +111,7 @@ const PositionRow: React.VFC<{
         onClick={onRowClick}
         role="checkbox"
         tabIndex={-1}
-        key={row.optionContractTokenKey}
+        key={row.market.optionMintKey.toString()}
       >
         <TableCell width="5%">
           {row.accounts.length > 1 && (
@@ -148,7 +146,7 @@ const PositionRow: React.VFC<{
           )}
         </TableCell>
       </TableRow>
-      <TableRow key={`${row.optionContractTokenKey}Collapsible`}>
+      <TableRow key={`${row.market.optionMintKey}Collapsible`}>
         <TableCell
           style={{ borderWidth: 0, padding: 0, margin: 0 }}
           colSpan={7}

--- a/src/components/pages/OpenPositions/WrittenOptionsTable/WrittenOptionRow.js
+++ b/src/components/pages/OpenPositions/WrittenOptionsTable/WrittenOptionRow.js
@@ -34,7 +34,7 @@ export const WrittenOptionRow = React.memo(
     const ownedUAssetKey = ownedTokenAccounts[market.uAssetMint]?.[0]?.pubKey
     const ownedQAssetKey = ownedTokenAccounts[market.qAssetMint]?.[0]?.pubKey
     const ownedOptionTokenAccounts =
-      ownedTokenAccounts[market.optionMintAddress]
+      ownedTokenAccounts[market.optionMintKey.toString()]
     const { closeOptionPostExpiration } = useCloseWrittenOptionPostExpiration(
       market,
       ownedUAssetKey,

--- a/src/context/OptionsMarketsContext.tsx
+++ b/src/context/OptionsMarketsContext.tsx
@@ -1,10 +1,17 @@
 import React, { useState, createContext } from 'react'
 import PropTypes from 'prop-types'
 
-const OptionsMarketsContext = createContext()
+import { OptionMarket } from '../types'
+
+const OptionsMarketsContext = createContext({
+  markets: {},
+  setMarkets: null,
+  marketsLoading: false,
+  setMarketsLoading: null,
+})
 
 const OptionsMarketsProvider = ({ children }) => {
-  const [markets, setMarkets] = useState({})
+  const [markets, setMarkets] = useState<Record<string, OptionMarket>>({})
   const [marketsLoading, setMarketsLoading] = useState(false)
 
   return (

--- a/src/hooks/useCloseWrittenOptionPostExpiration.js
+++ b/src/hooks/useCloseWrittenOptionPostExpiration.js
@@ -65,7 +65,7 @@ export const useCloseWrittenOptionPostExpiration = (
           const ix = await closePostExpirationCoveredCallInstruction({
             // eslint-disable-line
             programId: new PublicKey(endpoint.programId),
-            optionMarketKey: new PublicKey(market.optionMarketDataAddress),
+            optionMarketKey: market.optionMarketKey,
             optionMintKey: market.optionMintKey,
             underlyingAssetDestKey: _underlyingAssetDestKey,
             underlyingAssetPoolKey: market.underlyingAssetPoolKey,
@@ -146,7 +146,7 @@ export const useCloseWrittenOptionPostExpiration = (
     [
       underlyingAssetDestKey,
       market.uAssetMint,
-      market.optionMarketDataAddress,
+      market.optionMarketKey,
       market.optionMintKey,
       market.underlyingAssetPoolKey,
       market.writerTokenMintKey,

--- a/src/hooks/useExerciseOpenPosition.js
+++ b/src/hooks/useExerciseOpenPosition.js
@@ -23,8 +23,8 @@ const useExerciseOpenPosition = (
         connection,
         payer: { publicKey: pubKey },
         programId: endpoint.programId,
-        optionMintKey: new PublicKey(market.optionMintAddress),
-        optionMarketKey: new PublicKey(market.optionMarketDataAddress),
+        optionMintKey: market.optionMintKey,
+        optionMarketKey: market.optionMarketKey,
         exerciserQuoteAssetKey: new PublicKey(exerciserQuoteAssetAddress),
         exerciserUnderlyingAssetKey: new PublicKey(
           exerciserUnderlyingAssetAddress,

--- a/src/hooks/useInitializeMarkets.tsx
+++ b/src/hooks/useInitializeMarkets.tsx
@@ -12,6 +12,8 @@ import useWallet from './useWallet'
 import { buildSolanaExplorerUrl } from '../utils/solanaExplorer'
 import { OptionsMarketsContext } from '../context/OptionsMarketsContext'
 
+import { OptionMarket } from '../types'
+
 type InitMarketParams = {
   amountPerContract: BigNumber
   quoteAmountsPerContract: BigNumber[]
@@ -74,9 +76,8 @@ export const useInitializeMarkets = (): ((
               createAccountsSigned.serialize(),
             )
 
-            const createAccountsExplorerUrl = buildSolanaExplorerUrl(
-              createAccountsTxId,
-            )
+            const createAccountsExplorerUrl =
+              buildSolanaExplorerUrl(createAccountsTxId)
 
             pushNotification({
               severity: 'info',
@@ -130,9 +131,8 @@ export const useInitializeMarkets = (): ((
             const transaction = new Transaction()
             transaction.add(initializeMarketIx)
             transaction.feePayer = wallet.publicKey
-            const {
-              blockhash: initMarketBlockHash,
-            } = await connection.getRecentBlockhash()
+            const { blockhash: initMarketBlockHash } =
+              await connection.getRecentBlockhash()
             transaction.recentBlockhash = initMarketBlockHash
 
             const signed = await wallet.signTransaction(transaction)
@@ -162,20 +162,18 @@ export const useInitializeMarkets = (): ((
               ),
             })
 
-            const marketData = {
+            const marketData: OptionMarket = {
               key: `${expiration}-${uAssetSymbol}-${qAssetSymbol}-${amountPerContract.toString()}-${amountPerContract.toString()}/${qAmount.toString()}`,
               amountPerContract,
               quoteAmountPerContract: qAmount,
-              size: amountPerContract.toNumber(),
-              strikePrice: qAmount.div(amountPerContract).toNumber(),
+              size: `${amountPerContract.toNumber()}`,
+              strikePrice: `${qAmount.div(amountPerContract).toNumber()}`,
               uAssetSymbol,
               qAssetSymbol,
               uAssetMint,
               qAssetMint,
               expiration,
-              optionMarketDataAddress: optionMarketKey.toString(),
               optionMarketKey,
-              optionMintAddress: optionMintKey.toString(),
               optionMintKey,
               writerTokenMintKey,
               underlyingAssetPoolKey,

--- a/src/hooks/useOpenPositions.ts
+++ b/src/hooks/useOpenPositions.ts
@@ -15,7 +15,7 @@ const useOpenPositions = (): Record<string, TokenAccount[]> => {
   return useMemo(() => {
     const positions = Object.keys(markets).reduce((acc, marketKey) => {
       const accountsWithHoldings = ownedTokenAccounts[
-        markets[marketKey].optionMintAddress
+        markets[marketKey].optionMintKey.toString()
       ]?.filter((optionTokenAcct) => optionTokenAcct.amount > 0)
       if (accountsWithHoldings?.length) {
         acc[marketKey] = accountsWithHoldings

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export type TokenAccount = {
 }
 
 export type OptionMarket = {
+  key: string
   // Leave these in tact as BigNumbers to use later for creating the reciprocal put/call
   amountPerContract: BigNumber
   quoteAmountPerContract: BigNumber
@@ -26,16 +27,13 @@ export type OptionMarket = {
   uAssetMint: string
   qAssetMint: string
   strikePrice: string
-  /** @deprecated */
-  optionMintAddress: string
   optionMintKey: PublicKey
-  /** @deprecated */
-  optionMarketDataAddress: string
   optionMarketKey: PublicKey
   writerTokenMintKey: PublicKey
   underlyingAssetPoolKey: PublicKey
-  quoteAssetPoolKey: PublicKey
   underlyingAssetMintKey: PublicKey
+  quoteAssetPoolKey: PublicKey
+  quoteAssetMintKey: PublicKey
 }
 
 export type OptionMarketMeta = {


### PR DESCRIPTION
Changes here:
- Remove the deprecated `optionMintAddress` and `optionMarketDataAddress` key/values everywhere they're used in the app and use the publicKey types instead
- Enforce the usage of the OptionMarket type in the option markets  context, the fetch markets function, and in the initialize market function

Todo for separate PR:
- Update psyoptions-ts so that it returns all of the keys/values needed by the frontend as the correct type in the marketData object when getting markets by SPL support.
