### PR TITLE
Show wallet balances on markets page

### DIFF
--- a/src/components/pages/Markets/Markets.js
+++ b/src/components/pages/Markets/Markets.js
@@ -35,6 +35,8 @@ import Loading from '../../Loading'
 import OpenOrders from '../../OpenOrders'
 import { ContractSizeSelector } from '../../ContractSizeSelector'
 
+import Balances from './MarketsBalances'
+
 import { TCellLoading, THeadCell, TCellStrike, PageButton } from './styles'
 import { MarketDataProvider } from '../../../context/MarketDataContext'
 
@@ -300,6 +302,9 @@ const Markets = () => {
                   onChange={updateContractSize}
                   value={contractSize}
                 />
+              </Box>
+              <Box py={[2, 2, 0]}>
+                <Balances />
               </Box>
             </Box>
             <Box px={[1, 1, 0]} py={[2, 2, 1]} width={['100%', '100%', 'auto']}>

--- a/src/components/pages/Markets/MarketsBalances.tsx
+++ b/src/components/pages/Markets/MarketsBalances.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import Box from '@material-ui/core/Box'
+import Avatar from '@material-ui/core/Avatar'
+import { LAMPORTS_PER_SOL } from '@solana/web3.js'
+
+import useWallet from '../../../hooks/useWallet'
+import useAssetList from '../../../hooks/useAssetList'
+import useOwnedTokenAccounts from '../../../hooks/useOwnedTokenAccounts'
+
+import { WRAPPED_SOL_ADDRESS, getHighestAccount } from '../../../utils/token'
+
+const Balances: React.FC = () => {
+  const { balance, connected } = useWallet()
+  const { uAsset, qAsset, assetListLoading } = useAssetList()
+  const { ownedTokenAccounts, loadingOwnedTokenAccounts } =
+    useOwnedTokenAccounts()
+  const uAssetAccounts = ownedTokenAccounts[uAsset?.mintAddress] || []
+  const qAssetAccounts = ownedTokenAccounts[qAsset?.mintAddress] || []
+
+  const qAssetBalance =
+    (getHighestAccount(qAssetAccounts)?.amount || 0) / 10 ** qAsset?.decimals
+  let uAssetBalance =
+    (getHighestAccount(uAssetAccounts)?.amount || 0) / 10 ** uAsset?.decimals
+  if (uAsset?.mintAddress === WRAPPED_SOL_ADDRESS) {
+    // if asset is wrapped Sol, use balance of wallet account
+    uAssetBalance = balance / LAMPORTS_PER_SOL
+  }
+
+  if (!loadingOwnedTokenAccounts && !assetListLoading && connected) {
+    return (
+      <Box
+        display="flex"
+        flexDirection={['row', 'row', 'column']}
+        alignItems="flex-start"
+        fontSize={'14px'}
+        px={[1, 1, 0]}
+      >
+        <Box px={[1, 1, 0]}>Wallet Balances:</Box>
+        <Box display="flex" px={[1, 1, 0]} pt={[0, 0, 1]}>
+          <Box display="flex" flexDirection={'row'} alignItems="center" mr={1}>
+            <Avatar
+              style={{ width: '20px', height: '20px', marginRight: '6px' }}
+              src={uAsset?.icon}
+            />{' '}
+            {uAssetBalance.toFixed(2)} {uAsset?.tokenSymbol}
+          </Box>
+          <Box display="flex" flexDirection={'row'} alignItems="center" mx={1}>
+            <Avatar
+              style={{ width: '20px', height: '20px', marginRight: '6px' }}
+              src={qAsset?.icon}
+            />{' '}
+            {qAssetBalance.toFixed(2)} {qAsset?.tokenSymbol}
+          </Box>
+        </Box>
+      </Box>
+    )
+  }
+
+  return null
+}
+
+export default Balances


### PR DESCRIPTION
Looks like this when loaded + connected:
![Screen Shot 2021-06-16 at 10 24 12 PM](https://user-images.githubusercontent.com/9023427/122321745-5cd80300-cef2-11eb-83ac-0fd2e97b8100.png)

If you aren't connected or the balances haven't finished loading, it will show nothing.

I put it on the left side here instead of under the asset pair select because it looked terrible there
