### PR TITLE
Fix expiration dates bug

### DIFF
--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -6,9 +6,12 @@ export const getLastFridayOfMonths = (n = 10) =>
   Array(n)
     .fill(0)
     .map((_, i) => {
-      const lastDay = moment.utc().endOf('month').add(i, 'month')
+      const lastDay = moment
+        .utc()
+        .startOf('month')
+        .add(i, 'month')
+        .endOf('month')
       const lastFriday = lastDay.subtract(subtractDays[lastDay.day()], 'day')
       return lastFriday
     })
     .filter((date) => date.isSameOrAfter(moment.utc()))
-    


### PR DESCRIPTION
This changes the moment code slightly to make sure it always gets the very last Friday of the month. The issue was that it was just adding N months to the end of the current month and then subtracting from there to get the last Friday. So this month, the last day of the month was the 30th, but in December the last day is the 31st and it happens to be a Friday, so that was getting ignored by the function because it was starting from the 30th. It should be fixed now.