### PR TITLE
Add color to the buy or sell text on open orders

### DIFF
--- a/src/components/OpenOrders/OpenOrdersForMarket.tsx
+++ b/src/components/OpenOrders/OpenOrdersForMarket.tsx
@@ -9,6 +9,8 @@ import { useSerumOrderbooks } from '../../context/SerumOrderbookContext'
 import { useSubscribeOpenOrders, useCancelOrder } from '../../hooks/Serum'
 import useNotifications from '../../hooks/useNotifications'
 
+import theme from '../../utils/theme'
+
 import { TCell } from './OpenOrderStyles'
 
 // Render all open orders for a given market as table rows
@@ -69,7 +71,16 @@ const OpenOrdersForMarket: React.FC<{
     actualOpenOrders.map((order) => {
       return (
         <TableRow hover key={`${JSON.stringify(order)}`}>
-          <TCell>{order?.side}</TCell>
+          <TCell
+            style={{
+              color:
+                order?.side === 'buy'
+                  ? theme.palette.success.main
+                  : theme.palette.error.main,
+            }}
+          >
+            {order?.side}
+          </TCell>
           <TCell>{type}</TCell>
           <TCell>{`${qAssetSymbol}/${uAssetSymbol}`}</TCell>
           <TCell>
@@ -78,7 +89,16 @@ const OpenOrdersForMarket: React.FC<{
           <TCell>{strikePrice}</TCell>
           <TCell>{`${contractSize} ${uAssetSymbol}`}</TCell>
           <TCell>{order?.size}</TCell>
-          <TCell>{order?.price}</TCell>
+          <TCell
+            style={{
+              color:
+                order?.side === 'buy'
+                  ? theme.palette.success.main
+                  : theme.palette.error.main,
+            }}
+          >
+            {order?.price}
+          </TCell>
           {/* <TCell>TODO</TCell> */}
           <TCell align="right">
             <Button


### PR DESCRIPTION
This is what I thought makes sense, color the buy/sell text and the price:
![Screen Shot 2021-06-16 at 10 55 14 PM](https://user-images.githubusercontent.com/9023427/122324027-17b5d000-cef6-11eb-93a0-ac5a7841aded.png)

If you guys think it should be the text of the entire row, I can try that out. I just think that would make these a little harder to read, and just having the color on the price and the order side seems good to me.
