### PR TITLE
Fix small issue with background color on market page rows

### DIFF
--- a/src/components/pages/Markets/CallPutRow.js
+++ b/src/components/pages/Markets/CallPutRow.js
@@ -178,10 +178,10 @@ const CallPutRow = ({
 
   const callCellStyle = row.strike?.lte(markPrice)
     ? { backgroundColor: theme.palette.background.tableHighlight }
-    : undefined
+    : { backgroundColor: theme.palette.background.marketsCallPutRow }
   const putCellStyle = row.strike?.gte(markPrice)
     ? { backgroundColor: theme.palette.background.tableHighlight }
-    : undefined
+    : { backgroundColor: theme.palette.background.marketsCallPutRow }
 
   const openBuySellModal = (callOrPut, price = 0) => {
     // only allow full row clicking open for initialized markets

--- a/src/components/pages/Markets/styles.js
+++ b/src/components/pages/Markets/styles.js
@@ -36,7 +36,7 @@ export const TCellLoading = withStyles({
     fontSize: '14px',
     height: '48px',
     border: 'none',
-    background: theme.palette.background.medium,
+    background: 'transparent',
   },
 })(TableCell)
 
@@ -81,6 +81,7 @@ export const TCellStrike = withStyles({
 
 export const TRow = withStyles({
   hover: {
+    backgroundColor: `${theme.palette.background.medium}`,
     '&:hover': {
       backgroundColor: `${theme.palette.background.lighter} !important`
     }


### PR DESCRIPTION
Noticed the "hover" background color wasn't applying to the out of the money "loading" rows, so I fixed that.