### PR TITLE
[fix] Settle puts currency

### DIFF
--- a/src/components/BuySellDialog/BuySellDialog.tsx
+++ b/src/components/BuySellDialog/BuySellDialog.tsx
@@ -579,9 +579,9 @@ const BuySellDialog: React.VFC<{
                     }. Mint/Sell will lock the required collateral (${collateralRequired} ${uAssetSymbol}) until the contract expires or is exercised.`}
                   </Box>
                   <UnsettledFunds
-                    qAssetSymbol={qAssetSymbol}
+                    qAssetSymbol={type === 'call' ? qAssetSymbol : uAssetSymbol}
                     serumKey={serumKey}
-                    qAssetDecimals={qAssetDecimals}
+                    qAssetDecimals={type === 'call' ? qAssetDecimals : uAssetDecimals}
                   />
                 </>
               ) : !connected ? (


### PR DESCRIPTION
https://github.com/mithraiclabs/psyoptions-frontend/issues/419

so now for both BTCUSD calls and puts, filling a bid by selling into it will give unsettled funds in USDC.

![image](https://user-images.githubusercontent.com/28270253/123491364-5bca6400-d5cb-11eb-9f1a-cb5b5a635149.png)
