### PR TITLE
Fix claim quote button

### DIFF
--- a/src/components/pages/OpenPositions/OpenPositions.js
+++ b/src/components/pages/OpenPositions/OpenPositions.js
@@ -111,7 +111,7 @@ const OpenPositions = () => {
             }}
           >
             <Box
-              minWidth="850px"
+              minWidth="880px"
               minHeight="514px"
               display="flex"
               flexDirection="column"

--- a/src/components/pages/OpenPositions/WrittenOptionsTable/WrittenOptionRow.js
+++ b/src/components/pages/OpenPositions/WrittenOptionsTable/WrittenOptionRow.js
@@ -227,14 +227,21 @@ export const WrittenOptionRow = React.memo(
                 </Box>
               }
             >
-              <Button
-                color="primary"
-                variant="outlined"
-                onClick={exchangeWriterTokenForQuote}
-                style={{ marginLeft: holdsContracts ? 8 : 0 }}
+              <Box
+                display="flex"
+                alignItems="center"
+                justifyContent="flex-start"
+                p={1}
               >
-                Claim Quote
-              </Button>
+                <Button
+                  color="primary"
+                  variant="outlined"
+                  onClick={exchangeWriterTokenForQuote}
+                  style={{ marginLeft: holdsContracts ? 8 : 0 }}
+                >
+                  Claim Quote
+                </Button>
+              </Box>
             </StyledTooltip>
           )}
         </Box>

--- a/src/components/pages/OpenPositions/WrittenOptionsTable/WrittenOptionsTable.js
+++ b/src/components/pages/OpenPositions/WrittenOptionsTable/WrittenOptionsTable.js
@@ -40,7 +40,7 @@ export const WrittenOptionsTable = React.memo(() => {
       }}
     >
       <Box
-        minWidth="850px"
+        minWidth="880px"
         minHeight="514px"
         display="flex"
         flexDirection="column"


### PR DESCRIPTION
I noticed the claim quote button wasn't left aligned and was able to have a line break in it when the screen got too small, so that is fixed here. Forgot to test that before merging the original PR
