### PR TITLE
Quick and dirty fix for open order sizes bug

### DIFF
--- a/src/components/OpenOrders/OpenOrdersForMarket.tsx
+++ b/src/components/OpenOrders/OpenOrdersForMarket.tsx
@@ -2,16 +2,23 @@ import React from 'react'
 import TableRow from '@material-ui/core/TableRow'
 import Button from '@material-ui/core/Button'
 import moment from 'moment'
+import { PublicKey } from '@solana/web3.js'
 
 import useSerum from '../../hooks/useSerum'
 import { useSerumOpenOrders } from '../../context/SerumOpenOrdersContext'
 import { useSerumOrderbooks } from '../../context/SerumOrderbookContext'
 import { useSubscribeOpenOrders, useCancelOrder } from '../../hooks/Serum'
-import useNotifications from '../../hooks/useNotifications'
 
 import theme from '../../utils/theme'
 
 import { TCell } from './OpenOrderStyles'
+
+type SerumBidOrAsk = {
+  side: string
+  price: number
+  size: number
+  openOrdersAddress: PublicKey
+}
 
 // Render all open orders for a given market as table rows
 const OpenOrdersForMarket: React.FC<{
@@ -35,7 +42,6 @@ const OpenOrdersForMarket: React.FC<{
   const [orderbooks] = useSerumOrderbooks()
   const [openOrders] = useSerumOpenOrders()
   const { serumMarket } = serumMarkets[serumKey] || {}
-  const { pushNotification } = useNotifications()
 
   const handleCancelOrder = useCancelOrder(serumKey)
 
@@ -50,68 +56,103 @@ const OpenOrdersForMarket: React.FC<{
   }
 
   const { bidOrderbook, askOrderbook } = orderbooks[serumKey]
-  let actualOpenOrders
 
-  try {
-    actualOpenOrders = serumMarket.market.filterForOpenOrders(
-      bidOrderbook || [],
-      askOrderbook || [],
-      openOrders[serumKey]?.orders || [],
-    )
-  } catch (err) {
-    pushNotification({
-      severity: 'error',
-      message: `Couldn't display open orders for option market: ${uAssetSymbol}/${qAssetSymbol} ${type} @ strike ${strikePrice}`,
-    })
-    console.error(err)
-  }
+  const bids = [...(bidOrderbook || [])] as SerumBidOrAsk[]
+  const asks = [...(askOrderbook || [])] as SerumBidOrAsk[]
+  const openOrderAccounts = openOrders[serumKey]?.orders || []
+  const bidPrices = {}
+  const askPrices = {}
+
+  // Some manual bugfixing:
+  // If this wallet has multiple open orders of same price
+  // We need to subtract the size of all orders beyond the first order from the first one
+  // Seems to be a bug in the serum code that returns orderbooks
+  // The first order of a given price for a wallet returns the total size the wallet has placed at that price, rather than the single order size
+
+  asks.forEach((order) => {
+    if (
+      openOrderAccounts.some((a) => order.openOrdersAddress.equals(a.address))
+    ) {
+      const askPricesArr = askPrices[`${order.price}`]
+      if (askPricesArr?.length > 0) {
+        askPricesArr[0].size -= order.size
+        askPricesArr.push(order)
+      } else {
+        askPrices[`${order.price}`] = [order]
+      }
+    }
+  })
+
+  // We can modify the bid order sizes in-place if we reverse them first
+  // The order with "incorrect size" will be at the end for bids, when reversed it will be at the beginning
+  bids.reverse()
+  bids.forEach((order) => {
+    if (
+      openOrderAccounts.some((a) => order.openOrdersAddress.equals(a.address))
+    ) {
+      const bidPricesArr = bidPrices[`${order.price}`]
+      if (bidPricesArr?.length > 0) {
+        bidPricesArr[0].size -= order.size
+        bidPricesArr.push(order)
+      } else {
+        bidPrices[`${order.price}`] = [order]
+      }
+    }
+  })
+
+  const actualOpenOrders = [
+    ...Object.values(bidPrices),
+    ...Object.values(askPrices),
+  ].flat() as SerumBidOrAsk[]
 
   return (
-    actualOpenOrders &&
-    actualOpenOrders.map((order) => {
-      return (
-        <TableRow hover key={`${JSON.stringify(order)}`}>
-          <TCell
-            style={{
-              color:
-                order?.side === 'buy'
-                  ? theme.palette.success.main
-                  : theme.palette.error.main,
-            }}
-          >
-            {order?.side}
-          </TCell>
-          <TCell>{type}</TCell>
-          <TCell>{`${qAssetSymbol}/${uAssetSymbol}`}</TCell>
-          <TCell>
-            {`${moment.utc(expiration * 1000).format('LL')} 23:59:59 UTC`}
-          </TCell>
-          <TCell>{strikePrice}</TCell>
-          <TCell>{`${contractSize} ${uAssetSymbol}`}</TCell>
-          <TCell>{order?.size}</TCell>
-          <TCell
-            style={{
-              color:
-                order?.side === 'buy'
-                  ? theme.palette.success.main
-                  : theme.palette.error.main,
-            }}
-          >
-            {order?.price}
-          </TCell>
-          {/* <TCell>TODO</TCell> */}
-          <TCell align="right">
-            <Button
-              variant="outlined"
-              color="primary"
-              onClick={() => handleCancelOrder(order)}
-            >
-              Cancel
-            </Button>
-          </TCell>
-        </TableRow>
-      )
-    })
+    <>
+      {actualOpenOrders &&
+        actualOpenOrders.map((order) => {
+          return (
+            <TableRow hover key={`${JSON.stringify(order)}`}>
+              <TCell
+                style={{
+                  color:
+                    order?.side === 'buy'
+                      ? theme.palette.success.main
+                      : theme.palette.error.main,
+                }}
+              >
+                {order?.side}
+              </TCell>
+              <TCell>{type}</TCell>
+              <TCell>{`${qAssetSymbol}/${uAssetSymbol}`}</TCell>
+              <TCell>
+                {`${moment.utc(expiration * 1000).format('LL')} 23:59:59 UTC`}
+              </TCell>
+              <TCell>{strikePrice}</TCell>
+              <TCell>{`${contractSize} ${uAssetSymbol}`}</TCell>
+              <TCell>{order?.size}</TCell>
+              <TCell
+                style={{
+                  color:
+                    order?.side === 'buy'
+                      ? theme.palette.success.main
+                      : theme.palette.error.main,
+                }}
+              >
+                {order?.price}
+              </TCell>
+              {/* <TCell>TODO</TCell> */}
+              <TCell align="right">
+                <Button
+                  variant="outlined"
+                  color="primary"
+                  onClick={() => handleCancelOrder(order)}
+                >
+                  Cancel
+                </Button>
+              </TCell>
+            </TableRow>
+          )
+        })}
+    </>
   )
 }
 


### PR DESCRIPTION
I don't know if this is the right way to do this fix, but this does fix the UI display for the issue noted in: https://github.com/mithraiclabs/psyoptions-frontend/issues/392

I think there's might be some bug in the serum code that returns bids and asks for a specific wallet, because when you have multiple orders at the same price, the first one (or last one, in the case of bids) is always the total number of all your open orders at the same price. 

I don't know if it's really a bug, or it's a feature and I'm not getting the data structure of their orderbook, but in any case I was able to solve this by grouping the wallet's open orders by price and subtracting the size of any orders after the first from the first one. For the bids I just reversed the array that comes from serum to make sure the one with the incorrect size comes first. 

The code is ugly and I'd rather not have to do this, but I couldn't find another solution and this issue has been open for a while.

Screenshots post-fix:
![Screen Shot 2021-07-08 at 11 44 13 PM](https://user-images.githubusercontent.com/9023427/125021189-24869900-e048-11eb-98b2-b200ef601fe7.png)
![Screen Shot 2021-07-08 at 11 34 48 PM](https://user-images.githubusercontent.com/9023427/125021186-23ee0280-e048-11eb-87d6-128d0b851064.png)
![Screen Shot 2021-07-08 at 11 44 08 PM](https://user-images.githubusercontent.com/9023427/125021187-24869900-e048-11eb-822f-a11d1a70cbec.png)
