### PR TITLE
[fix] Seedlocalchain script use next exp date

### DIFF
--- a/scripts/seedLocalChain.ts
+++ b/scripts/seedLocalChain.ts
@@ -121,8 +121,9 @@ const initializeMarket = async (
 }
 
 ;(async () => {
-  // create markets for the end of the current month
-  const expirationDate = getLastFridayOfMonths(1)[0]
+  // create markets for the end of the current month,
+  // end of next month if last friday on this month passed
+  const expirationDate = getLastFridayOfMonths(1)[0] ? getLastFridayOfMonths(1)[0] : getLastFridayOfMonths(2)[0]
   // We have to divide the JS timestamp by 1,000 to get the timestamp in miliseconds
   const expirationUnixTimestamp = expirationDate.unix()
   const assets = getAssetsByNetwork(ClusterName.localhost)

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,4 +1,4 @@
-import { createMuiTheme } from '@material-ui/core/styles'
+import { createTheme } from '@material-ui/core/styles'
 
 type Gradients = {
   secondary: string
@@ -9,7 +9,7 @@ type Gradients = {
   info: string
 }
 
-declare module '@material-ui/core/styles/createMuiTheme' {
+declare module '@material-ui/core/styles/createTheme' {
   interface Theme {
     gradients?: Gradients
   }
@@ -50,7 +50,7 @@ declare module '@material-ui/core/styles/createPalette' {
   }
 }
 
-const theme = createMuiTheme({
+const theme = createTheme({
   gradients: {
     secondary: 'linear-gradient(90deg, #24001A 0%, #790068 50%, #D18641 100%)',
     secondaryPrimary: 'linear-gradient(90deg, #DD3E76 -0.83%, #1D4DC9 100%)',


### PR DESCRIPTION
Just need to account for final fridays that already passed, otherwise it fails. The change will set it to the next month's final friday in that scenario.

also a Material ui variable name update