### PR TITLE
Update programId for PsyOptions instructions to come from markets meta

### DIFF
--- a/src/hooks/useClosePosition.ts
+++ b/src/hooks/useClosePosition.ts
@@ -63,7 +63,7 @@ export const useClosePosition = (
           }
 
           const closePositionIx = await closePositionInstruction({
-            programId: new PublicKey(endpoint.programId),
+            programId: new PublicKey(market.psyOptionsProgramId),
             optionMarketKey: market.optionMarketKey,
             underlyingAssetPoolKey: market.underlyingAssetPoolKey,
             optionMintKey: market.optionMintKey,
@@ -130,7 +130,7 @@ export const useClosePosition = (
       market.underlyingAssetPoolKey,
       market.optionMintKey,
       market.writerTokenMintKey,
-      endpoint.programId,
+      market.psyOptionsProgramId,
       optionTokenSrcKey,
       pubKey,
       writerTokenSourceKey,

--- a/src/hooks/useCloseWrittenOptionPostExpiration.ts
+++ b/src/hooks/useCloseWrittenOptionPostExpiration.ts
@@ -63,7 +63,7 @@ export const useCloseWrittenOptionPostExpiration = (
             _underlyingAssetDestKey = wrappedSolAccount.publicKey
           }
           const ix = await closePostExpirationCoveredCallInstruction({
-            programId: new PublicKey(endpoint.programId),
+            programId: new PublicKey(market.psyOptionsProgramId),
             optionMarketKey: market.optionMarketKey,
             underlyingAssetDestKey: _underlyingAssetDestKey,
             underlyingAssetPoolKey: market.underlyingAssetPoolKey,
@@ -128,7 +128,7 @@ export const useCloseWrittenOptionPostExpiration = (
       market.optionMarketKey,
       market.underlyingAssetPoolKey,
       market.writerTokenMintKey,
-      endpoint.programId,
+      market.psyOptionsProgramId,
       writerTokenSourceKey,
       pubKey,
       connection,

--- a/src/hooks/useExchangeWriterTokenForQuote.ts
+++ b/src/hooks/useExchangeWriterTokenForQuote.ts
@@ -51,7 +51,7 @@ export const useExchangeWriterTokenForQuote = (
         _quoteAssetDestKey = wrappedSolAccount.publicKey
       }
       const ix = await exchangeWriterTokenForQuoteInstruction({
-        programId: new PublicKey(endpoint.programId),
+        programId: new PublicKey(market.psyOptionsProgramId),
         optionMarketKey: market.optionMarketKey,
         writerTokenMintKey: market.writerTokenMintKey,
         writerTokenSourceAuthorityKey: pubKey,
@@ -91,7 +91,7 @@ export const useExchangeWriterTokenForQuote = (
     market.optionMarketKey,
     market.writerTokenMintKey,
     market.quoteAssetPoolKey,
-    endpoint.programId,
+    market.psyOptionsProgramId,
     pubKey,
     writerTokenSourceKey,
     connection,

--- a/src/hooks/useExerciseOpenPosition.tsx
+++ b/src/hooks/useExerciseOpenPosition.tsx
@@ -22,7 +22,7 @@ const useExerciseOpenPosition = (
       const { transaction: tx } = await exerciseCoveredCall({
         connection,
         payerKey: pubKey,
-        programId: endpoint.programId,
+        programId: market.psyOptionsProgramId,
         optionMintKey: market.optionMintKey,
         optionMarketKey: market.optionMarketKey,
         exerciserQuoteAssetKey: new PublicKey(exerciserQuoteAssetAddress),
@@ -52,7 +52,6 @@ const useExerciseOpenPosition = (
   }, [
     connection,
     pubKey,
-    endpoint.programId,
     market,
     exerciserQuoteAssetAddress,
     exerciserUnderlyingAssetAddress,

--- a/src/hooks/useInitializeMarkets.tsx
+++ b/src/hooks/useInitializeMarkets.tsx
@@ -147,6 +147,7 @@ export const useInitializeMarkets = (): ((
               underlyingAssetMintKey,
               quoteAssetPoolKey,
               quoteAssetMintKey,
+              psyOptionsProgramId: programId.toString(),
             }
 
             return marketData

--- a/src/hooks/useOptionsMarkets.tsx
+++ b/src/hooks/useOptionsMarkets.tsx
@@ -126,6 +126,7 @@ const useOptionsMarkets = () => {
             quoteAssetPoolKey,
             quoteAssetMintKey,
             serumMarketKey: serumMarket.address,
+            psyOptionsProgramId: endpoint.programId,
           }
 
           const key = `${newMarket.expiration}-${newMarket.uAssetSymbol}-${
@@ -204,6 +205,7 @@ const useOptionsMarkets = () => {
           quoteAssetPoolKey: new PublicKey(market.quoteAssetPoolAddress),
           quoteAssetMintKey: new PublicKey(market.quoteAssetMint),
           serumMarketKey: new PublicKey(market.serumMarketAddress),
+          psyOptionsProgramId: market.psyOptionsProgramId,
         }
 
         const key = `${newMarket.expiration}-${newMarket.uAssetSymbol}-${
@@ -278,7 +280,7 @@ const useOptionsMarkets = () => {
       const { transaction: mintTx } = await mintInstructions({
         numberOfContractsToMint: numberOfContracts,
         authorityPubkey: pubKey,
-        programId: new PublicKey(endpoint.programId),
+        programId: new PublicKey(marketData.psyOptionsProgramId),
         market: marketData,
         mintedOptionDestKey,
         writerTokenDestKey,

--- a/src/hooks/usePlaceSellOrder.tsx
+++ b/src/hooks/usePlaceSellOrder.tsx
@@ -30,7 +30,7 @@ const usePlaceSellOrder = (
 ): ((obj: PlaceSellOrderArgs) => Promise<void>) => {
   const { pushErrorNotification } = useNotifications()
   const { wallet, pubKey } = useWallet()
-  const { connection, endpoint } = useConnection()
+  const { connection } = useConnection()
   const { splTokenAccountRentBalance } = useSolanaMeta()
   const { subscribeToTokenAccount } = useOwnedTokenAccounts()
   const { sendSignedTransaction } = useSendTransaction()
@@ -59,7 +59,7 @@ const usePlaceSellOrder = (
         if (numberOfContractsToMint > 0) {
           // Mint missing contracs before placing order
           const { error, response } = await createMissingAccountsAndMint({
-            optionsProgramId: new PublicKey(endpoint.programId),
+            optionsProgramId: new PublicKey(optionMarket.psyOptionsProgramId),
             authorityPubkey: pubKey,
             owner: pubKey,
             market: optionMarket,
@@ -169,7 +169,6 @@ const usePlaceSellOrder = (
     [
       connection,
       createAdHocOpenOrdersSub,
-      endpoint.programId,
       pubKey,
       pushErrorNotification,
       sendSignedTransaction,

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,7 @@ export type OptionMarket = {
   quoteAssetPoolKey: PublicKey
   quoteAssetMintKey: PublicKey
   serumMarketKey?: PublicKey
+  psyOptionsProgramId: string
 }
 
 export type ChainRow = {


### PR DESCRIPTION
This updates the option market type to include the psyOptionsProgramId property form the markets meta package, and pass that into any instructions for our program besides initialize new market.

I THINK this covers all cases of the psyoptions program id needing to be pulled from the markets meta instead of the environment variable, when its an existing psyoptions market.

For the initialize new market, I did not make this change, because presumably we always want the initialize feature to create markets with the latest program id. Therefore, I also didn't remove the program id environment variable and it should still be updated to the latest program id.

If we want to change how this works, I'd suggest we update the markets meta package to include a "latest" program id for each network, in addition to the specific program ids for the supported markets, that we can pull into the front end and set as the canonical program id in the network context instead of using the environment variable.

Serum version of this coming later because it's significantly more difficult.