### PR TITLE
[Fix] Add last price state to selector

### DIFF
--- a/src/components/pages/Markets/ColumnDisplaySelector.tsx
+++ b/src/components/pages/Markets/ColumnDisplaySelector.tsx
@@ -20,6 +20,7 @@ export const ColumnDisplaySelector: React.FC<{
   showPriceChange: boolean
   showVolume: boolean
   showOI: boolean
+  showLastPrice: boolean
   setShowIV: React.Dispatch<React.SetStateAction<boolean>>
   setShowPriceChange: React.Dispatch<React.SetStateAction<boolean>>
   setShowVolume: React.Dispatch<React.SetStateAction<boolean>>
@@ -33,6 +34,7 @@ export const ColumnDisplaySelector: React.FC<{
     showPriceChange,
     showVolume,
     showOI,
+    showLastPrice,
     setShowIV,
     setShowPriceChange,
     setShowVolume,
@@ -150,7 +152,7 @@ export const ColumnDisplaySelector: React.FC<{
             <FormControlLabel
               control={
                 <Checkbox
-                  checked={showOI}
+                  checked={showLastPrice}
                   onChange={(e) => {
                     setShowLastPrice(e.target.checked)
                     if (e.target.checked) {

--- a/src/components/pages/Markets/MarketsTableHeader.tsx
+++ b/src/components/pages/Markets/MarketsTableHeader.tsx
@@ -80,6 +80,7 @@ export const MarketsTableHeader: React.FC<{
               showPriceChange={showPriceChange}
               showVolume={showVolume}
               showOI={showOI}
+              showLastPrice={showLastPrice}
               setShowIV={setShowIV}
               setShowPriceChange={setShowPriceChange}
               setShowVolume={setShowVolume}


### PR DESCRIPTION
quick fix. Toggling last price on and off messed up the table because the selector was reading another column's state