### PR TITLE
Populate dates from markets meta

### DIFF
--- a/src/components/NetworkMenu.tsx
+++ b/src/components/NetworkMenu.tsx
@@ -43,7 +43,7 @@ const NetworkMenu = () => {
   const loading = marketsLoading || assetListLoading
 
   const handleSelectNetwork = (network: Network) => {
-    if (loading) return
+    if (loading || network.name === endpoint.name) return
     setEndpoint(network)
     // Reset assets, markets, and chain when changing endpoint
     // This allows us to refresh everything when changing the endpoint

--- a/src/context/ExpirationDateContext.tsx
+++ b/src/context/ExpirationDateContext.tsx
@@ -1,45 +1,96 @@
+import { MarketMeta } from '@mithraic-labs/market-meta'
 import type { Moment } from 'moment'
 import moment from 'moment'
-import React, { createContext, useContext, useEffect } from 'react'
+import React, { createContext, useContext, useEffect, useState } from 'react'
 import useLocalStorageState from 'use-local-storage-state'
-
-import { getLastFridayOfMonths } from '../utils/dates'
+import useAssetList from '../hooks/useAssetList'
+import useConnection from '../hooks/useConnection'
 
 type DateContextValue = {
-  dates: Moment[]
   selectedDate: Moment | undefined
+  dates: Moment[]
   setSelectedDate: (date: Moment) => void
 }
 
-const dates = getLastFridayOfMonths(10)
-
 const ExpirationDateContext = createContext<DateContextValue>({
   selectedDate: undefined,
-  dates,
+  dates: [],
   setSelectedDate: () => {},
 })
 
-const defaultDate = dates[0].toISOString()
-
 const ExpirationDateProvider: React.FC = ({ children }) => {
-  const [_selectedDate, _setSelectedDate] = useLocalStorageState(
-    'selectedDate',
-    defaultDate,
-  )
+  const { endpoint } = useConnection()
+  const { uAsset, qAsset, assetListLoading } = useAssetList()
+  const [dates, setDates] = useState([])
+  const [_selectedDatesByAsset, _setSelectedDatesByAsset] =
+    useLocalStorageState('selectedDates', {})
 
+  const _selectedDate = _selectedDatesByAsset[uAsset?.tokenSymbol]
   const parsedDate = moment.utc(_selectedDate)
 
   useEffect(() => {
-    if (parsedDate.isBefore(moment.utc())) {
-      _setSelectedDate(dates[0].toISOString())
+    if (!assetListLoading && uAsset?.mintAddress && qAsset?.mintAddress) {
+      const markets =
+        MarketMeta[endpoint.name.toLowerCase()]?.optionMarkets || []
+
+      const expirationsForAssetPair = [
+        ...new Set(
+          markets
+            .filter(
+              (market) =>
+                market.underlyingAssetMint === uAsset?.mintAddress &&
+                market.quoteAssetMint === qAsset?.mintAddress,
+            )
+            .map((market) => market.expiration),
+        ),
+      ] as number[]
+
+      const newDates = expirationsForAssetPair
+        .sort((a, b) => a - b)
+        .map((timestamp) => moment.utc(timestamp * 1000))
+        .filter((date) => {
+          // TODO - do we want a way to show recently expired dates instead of just dropping them?
+          return date.isAfter(moment.utc())
+        })
+
+      setDates(newDates)
     }
-  }, [parsedDate, _setSelectedDate])
+  }, [
+    assetListLoading,
+    endpoint.name,
+    uAsset?.mintAddress,
+    qAsset?.mintAddress,
+  ])
+
+  useEffect(() => {
+    // Set default date or load user's stored date for current asset
+    if (
+      dates.length > 0 &&
+      (parsedDate.isBefore(moment.utc()) ||
+        !dates.some((d) => d.toISOString() === _selectedDate))
+    ) {
+      _setSelectedDatesByAsset((prevValue) => ({
+        ...prevValue,
+        [uAsset?.tokenSymbol]: dates[0].toISOString(),
+      }))
+    }
+  }, [
+    dates,
+    parsedDate,
+    _selectedDate,
+    _setSelectedDatesByAsset,
+    uAsset?.tokenSymbol,
+  ])
 
   const value = {
+    setDates,
     dates,
     selectedDate: parsedDate,
     setSelectedDate: (date: Moment) => {
-      _setSelectedDate(date.toISOString())
+      _setSelectedDatesByAsset((prevValue) => ({
+        ...prevValue,
+        [uAsset?.tokenSymbol]: date.toISOString(),
+      }))
     },
   }
 

--- a/src/hooks/useOptionsMarkets.tsx
+++ b/src/hooks/useOptionsMarkets.tsx
@@ -171,11 +171,11 @@ const useOptionsMarkets = () => {
         // So convert all BN types to BigNumber
         const amountPerContract = new BigNumber(
           market.underlyingAssetPerContract,
-        ).div(10 ** uAsset.decimals)
+        ).div(10 ** uAsset?.decimals)
 
         const quoteAmountPerContract = new BigNumber(
           market.quoteAssetPerContract,
-        ).div(10 ** qAsset.decimals)
+        ).div(10 ** qAsset?.decimals)
 
         const strike = quoteAmountPerContract.div(
           amountPerContract.toString(10),


### PR DESCRIPTION
This makes the dates in the expiration dropdown driven by the markets meta, and the dates in the dropdown change based on network selected and asset selected now.

I am also storing the last used expiration in local storage by underlying asset symbol. In this pull request I am not storing them separately for different networks, so if you switch networks it may reset to the default if the date doesn't exist in the other network. I thought separating the local storage state by network AND asset was an unnecessary complexity, but I could change it to store it by asset and network if desired.

I also fixed two small bugs that are unrelated:
- The network menu fucks things up if you click on the same network that's already connected, so now it does nothing in that case instead
- cannot read property decimals of undefined in useOptionMarkets.tsx