### PR TITLE
Fix locked asset rounding to work better

### DIFF
--- a/src/components/pages/OpenPositions/WrittenOptionsTable/WrittenOptionRow.tsx
+++ b/src/components/pages/OpenPositions/WrittenOptionsTable/WrittenOptionRow.tsx
@@ -139,9 +139,9 @@ export const WrittenOptionRow = React.memo(
     )?.icon
 
     const lockedAmount =
-      initialWriterTokenAccount.amount * parseInt(market.size, 10)
-    const lockedAmountDisplay = `${lockedAmount}`.match(/\./g)
-      ? `≈${lockedAmount.toFixed(2)}`
+      initialWriterTokenAccount.amount * parseFloat(market.size)
+    const lockedAmountDisplay = `${lockedAmount}`.match(/\.(.{4,})$/)
+      ? `≈${lockedAmount.toFixed(3)}`
       : lockedAmount
 
     useEffect(() => {


### PR DESCRIPTION
### Changes:
The logic for the locked asset rounding wasn't working well for 0.01 contract size. The fixes I made are:
- Use parseFloat instead of parseInt for market size
- Display up to 3 decimals instead of 2
- Only format with .toFixed and add the approximate sign when there are more than 3 decimals after the decimal point

### Examples:
Exactly 0.01 locked asset (or greater):
![Screen Shot 2021-08-19 at 7 52 41 PM](https://user-images.githubusercontent.com/9023427/130158576-9cfb7817-fbe4-4ce1-9e64-cb171c921756.png)

0.0033333 locked asset:
![Screen Shot 2021-08-19 at 7 52 13 PM](https://user-images.githubusercontent.com/9023427/130158593-d0881da6-046f-4738-9c81-d723e78e4257.png)

<0.001 locked asset:
![Screen Shot 2021-08-19 at 7 51 02 PM](https://user-images.githubusercontent.com/9023427/130158615-1868c5e8-cc2a-4fff-9f45-052fed11d863.png)

