### PR TITLE
Fix issue with sollet extension not being installed

### DIFF
--- a/src/utils/wallet/adapters/solletExtension.ts
+++ b/src/utils/wallet/adapters/solletExtension.ts
@@ -4,7 +4,7 @@ import { isBrowser } from '../../isNode'
 
 let solletExtAdaptor
 
-if (isBrowser) {
+if (isBrowser && (window as any)?.sollet) {
   solletExtAdaptor = new Wallet((window as any).sollet)
 }
 


### PR DESCRIPTION
There was a js error breaking the page if sollet extension was not installed. This should fix the issue by not creating a new Wallet instance at all.