### PR TITLE
Fix selecting single lines on initialize page, and fix link style

### DIFF
--- a/src/components/pages/InitializeMarket/InitializedMarkets.tsx
+++ b/src/components/pages/InitializeMarket/InitializedMarkets.tsx
@@ -48,14 +48,17 @@ export const InitializedMarkets: React.VFC = () => {
           </Box>
         </Box>
         <Box display="flex">
-          <Box fontSize={'12px'}>
-            <Box p={1}>
+          <Box px={1}>
+            <Box py={1} fontSize={'14px'}>
               Data from markets previously initialized by your browser in JSON
               format appears here.
             </Box>
-            <Box p={1} pt={0} display="block">
+            <Box py={1} px={0} display="block" fontSize={'14px'}>
               After initializing a market, you may submit a pull request to our{' '}
-              <Link href="https://github.com/mithraiclabs/psyoptions-ts/tree/master/packages/market-meta">
+              <Link
+                href="https://github.com/mithraiclabs/psyoptions-ts/tree/master/packages/market-meta"
+                style={{ textDecoration: 'underline' }}
+              >
                 market meta package
               </Link>{' '}
               for UI support.


### PR DESCRIPTION
This removes the click handler that selects the text area content, and updates the link style on the initialize page:

![Screen Shot 2021-08-31 at 11 45 40 AM](https://user-images.githubusercontent.com/9023427/131534301-b9b120ee-5227-4031-a2af-b13595065ced.png)
