### PR TITLE
Fix exercise button tooltip to show up and show the correct exercise price for contract size

### DIFF
--- a/src/components/pages/OpenPositions/PositionRow.tsx
+++ b/src/components/pages/OpenPositions/PositionRow.tsx
@@ -124,12 +124,18 @@ const PositionRow: React.VFC<{
       (optionType === 'put' ? row?.qAssetMintAddress : row?.uAssetMintAddress),
   )?.icon;
 
+  const exerciseCost = parseFloat(strike) * parseFloat(contractSize);
+  let exerciseCostString = exerciseCost.toString(10);
+  if (exerciseCostString.match(/\..{3,}/)) {
+    exerciseCostString = exerciseCost.toFixed(2);
+  }
+
   const exerciseTooltipLabel = `${
     optionType === 'put' ? 'Sell' : 'Purchase'
   } ${contractSize} ${
     (optionType === 'put' ? row?.qAssetSymbol : row?.uAssetSymbol) ||
     'underlying asset'
-  } for ${strike} ${
+  } for ${exerciseCostString} ${
     (optionType === 'put' ? row?.uAssetSymbol : row?.qAssetSymbol) ||
     'quote asset'
   }`;
@@ -182,14 +188,16 @@ const PositionRow: React.VFC<{
           {expired && <Box color={theme.palette.error.main}>Expired</Box>}
           {!expired && (
             <StyledTooltip title={<Box p={2}>{exerciseTooltipLabel}</Box>}>
-              <TxButton
-                color="primary"
-                variant="outlined"
-                onClick={handleExercisePosition}
-                loading={loading}
-              >
-                {loading ? 'Exercising' : 'Exercise'}
-              </TxButton>
+              <Box>
+                <TxButton
+                  color="primary"
+                  variant="outlined"
+                  onClick={handleExercisePosition}
+                  loading={loading}
+                >
+                  {loading ? 'Exercising' : 'Exercise'}
+                </TxButton>
+              </Box>
             </StyledTooltip>
           )}
         </Box>
@@ -234,14 +242,16 @@ const PositionRow: React.VFC<{
                     <StyledTooltip
                       title={<Box p={2}>{exerciseTooltipLabel}</Box>}
                     >
-                      <TxButton
-                        color="primary"
-                        variant="outlined"
-                        onClick={handleExercisePosition}
-                        loading={loading}
-                      >
-                        {loading ? 'Exercising' : 'Exercise'}
-                      </TxButton>
+                      <Box>
+                        <TxButton
+                          color="primary"
+                          variant="outlined"
+                          onClick={handleExercisePosition}
+                          loading={loading}
+                        >
+                          {loading ? 'Exercising' : 'Exercise'}
+                        </TxButton>
+                      </Box>
                     </StyledTooltip>
                   )}
                 </Box>


### PR DESCRIPTION
![Screen Shot 2021-08-31 at 12 41 52 PM](https://user-images.githubusercontent.com/9023427/131542719-2afe98ae-e3c7-4e56-a25c-66ea901b23f3.png)
![Screen Shot 2021-08-31 at 12 41 55 PM](https://user-images.githubusercontent.com/9023427/131542722-47abed7e-9fd3-4f1c-be38-22588fcc3e64.png)