### PR TITLE
derive option key from param inputs

### DIFF
--- a/pages/mint/index.tsx
+++ b/pages/mint/index.tsx
@@ -17,6 +17,7 @@ import ConnectButton from '../../src/components/ConnectButton';
 import theme from '../../src/utils/theme';
 import { useMintOptions } from '../../src/hooks/PsyOptionsAPI/useMintOptions';
 import { MintInfo } from '../../src/components/Mint/MintInfo';
+import { MintParamInput } from '../../src/components/Mint/MintParamInput';
 
 /**
  * Page to allow users to mint options that have been initialized.
@@ -92,10 +93,15 @@ const Mint: React.VFC = () => {
               mb={2}
               mx={2}
             >
+              <Box mb={1}>
+                Enter the public key for the option or enter the params below to
+                derive the address.
+              </Box>
               <TextField
                 label="Option public key (optionMarketKey)"
                 variant="filled"
                 onChange={onTextChange}
+                value={optionMarketAddress}
                 style={{
                   width: '100%',
                 }}
@@ -106,6 +112,7 @@ const Mint: React.VFC = () => {
                 </span>
               )}
             </Box>
+            <MintParamInput onUpdateDerivedAddress={setOptionMarketAddress} />
             <Box m={2}>
               Quantity
               <PlusMinusIntegerInput

--- a/src/components/InitializeMarket/InitOptionMarket.tsx
+++ b/src/components/InitializeMarket/InitOptionMarket.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useState } from 'react';
 import { PublicKey } from '@solana/web3.js';
-import DateFnsUtils from '@date-io/date-fns';
 import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 import Checkbox from '@material-ui/core/Checkbox';
@@ -10,9 +9,6 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Paper from '@material-ui/core/Paper';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import TextField from '@material-ui/core/TextField';
-import { KeyboardDatePicker } from '@material-ui/pickers/DatePicker';
-import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
-import MuiPickersUtilsProvider from '@material-ui/pickers/MuiPickersUtilsProvider';
 import Radio from '@material-ui/core/Radio';
 import { OptionMarketWithKey } from '@mithraic-labs/psy-american';
 import { BigNumber } from 'bignumber.js';
@@ -27,11 +23,11 @@ import useConnection from '../../hooks/useConnection';
 import { useInitializeSerumMarket } from '../../hooks/Serum/useInitializeSerumMarket';
 import { useInitializedMarkets } from '../../context/LocalStorage';
 import { useCheckIfMarketExists } from '../../hooks/PsyOptionsAPI/useCheckIfMarketExists';
-import { StyledTooltip } from '../Markets/styles';
 import ConnectButton from '../ConnectButton';
 import { useTokenMintInfo } from '../../hooks/useTokenMintInfo';
 import { SelectAssetOrEnterMint } from '../SelectAssetOrEnterMint';
 import useAssetList from '../../hooks/useAssetList';
+import { ExpirationInput } from '../Inputs/ExpirationInput';
 
 const darkBorder = `1px solid ${theme.palette.background.main}`;
 
@@ -252,44 +248,10 @@ export const InitOptionMarket: React.VFC = () => {
           <h2 style={{ margin: '10px 0 0' }}>Initialize New Market</h2>
         </Box>
 
-        <Box p={2} borderBottom={darkBorder} display="flex" alignItems="center">
-          Expires On:
-          <Box
-            display="flex"
-            flexWrap="wrap"
-            flexDirection="row"
-            alignItems="center"
-          >
-            <MuiPickersUtilsProvider utils={DateFnsUtils}>
-              <KeyboardDatePicker
-                autoOk
-                disablePast
-                variant="inline"
-                format="MM/dd/yyyy"
-                inputVariant="filled"
-                id="date-picker-inline"
-                label="MM/DD/YYYY"
-                value={selectorDate}
-                onChange={handleSelectedDateChange}
-                KeyboardButtonProps={{
-                  'aria-label': 'change date',
-                }}
-                style={{ marginLeft: theme.spacing(4) }}
-              />
-            </MuiPickersUtilsProvider>
-            <StyledTooltip
-              title={
-                <Box p={1}>
-                  All expirations occur at 23:59:59 UTC on any selected date.
-                </Box>
-              }
-            >
-              <Box p={2}>
-                <HelpOutlineIcon />
-              </Box>
-            </StyledTooltip>
-          </Box>
-        </Box>
+        <ExpirationInput
+          onChange={handleSelectedDateChange}
+          value={selectorDate}
+        />
 
         <Box display="flex" borderBottom={darkBorder}>
           <Box width="50%" p={2} borderRight={darkBorder}>

--- a/src/components/InitializeMarket/MarketExistsDialog.tsx
+++ b/src/components/InitializeMarket/MarketExistsDialog.tsx
@@ -88,12 +88,7 @@ export const MarketExistsDialog: React.VFC<{
   ]);
 
   return (
-    <Dialog
-      disableBackdropClick
-      disableEscapeKeyDown
-      onClose={dismiss}
-      open={!!optionMarket}
-    >
+    <Dialog disableEscapeKeyDown onClose={dismiss} open={!!optionMarket}>
       <DialogTitle>Option already exists</DialogTitle>
       <DialogContent>
         <DialogContentText>

--- a/src/components/Inputs/ExpirationInput.tsx
+++ b/src/components/Inputs/ExpirationInput.tsx
@@ -1,0 +1,61 @@
+import DateFnsUtils from '@date-io/date-fns';
+import Box from '@material-ui/core/Box';
+import { KeyboardDatePicker } from '@material-ui/pickers/DatePicker';
+import MuiPickersUtilsProvider from '@material-ui/pickers/MuiPickersUtilsProvider';
+import { MaterialUiPickersDate } from '@material-ui/pickers/typings/date';
+import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
+import React from 'react';
+import theme from '../../utils/theme';
+import { StyledTooltip } from '../Markets/styles';
+import { Moment } from 'moment';
+
+const darkBorder = `1px solid ${theme.palette.background.main}`;
+
+export const ExpirationInput: React.VFC<{
+  onChange: (
+    date: MaterialUiPickersDate,
+    value?: string | null | undefined,
+  ) => void;
+  value: Date | Moment;
+}> = ({ onChange, value }) => {
+  return (
+    <Box p={2} borderBottom={darkBorder} display="flex" alignItems="center">
+      Expires On:
+      <Box
+        display="flex"
+        flexWrap="wrap"
+        flexDirection="row"
+        alignItems="center"
+      >
+        <MuiPickersUtilsProvider utils={DateFnsUtils}>
+          <KeyboardDatePicker
+            autoOk
+            disablePast
+            variant="inline"
+            format="MM/dd/yyyy"
+            inputVariant="filled"
+            id="date-picker-inline"
+            label="MM/DD/YYYY"
+            value={value}
+            onChange={onChange}
+            KeyboardButtonProps={{
+              'aria-label': 'change date',
+            }}
+            style={{ marginLeft: theme.spacing(4) }}
+          />
+        </MuiPickersUtilsProvider>
+        <StyledTooltip
+          title={
+            <Box p={1}>
+              All expirations occur at 23:59:59 UTC on any selected date.
+            </Box>
+          }
+        >
+          <Box p={2}>
+            <HelpOutlineIcon />
+          </Box>
+        </StyledTooltip>
+      </Box>
+    </Box>
+  );
+};

--- a/src/components/Mint/MintParamInput.tsx
+++ b/src/components/Mint/MintParamInput.tsx
@@ -1,0 +1,175 @@
+import Box from '@material-ui/core/Box';
+import FormControl from '@material-ui/core/FormControl';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Radio from '@material-ui/core/Radio';
+import RadioGroup from '@material-ui/core/RadioGroup';
+import TextField from '@material-ui/core/TextField';
+import { deriveOptionKeyFromParams } from '@mithraic-labs/psy-american';
+import { BN } from '@project-serum/anchor';
+import { PublicKey } from '@solana/web3.js';
+import BigNumber from 'bignumber.js';
+import moment from 'moment';
+import React, { useEffect, useState } from 'react';
+import { useAmericanPsyOptionsProgram } from '../../hooks/useAmericanPsyOptionsProgram';
+import { useDecimalsForMint } from '../../hooks/useDecimalsForMint';
+import useNotifications from '../../hooks/useNotifications';
+import { OptionType } from '../../types';
+import theme from '../../utils/theme';
+import { ExpirationInput } from '../Inputs/ExpirationInput';
+import { SelectAssetOrEnterMint } from '../SelectAssetOrEnterMint';
+
+const darkBorder = `1px solid ${theme.palette.background.main}`;
+
+export const MintParamInput: React.VFC<{
+  onUpdateDerivedAddress: (key: string) => void;
+}> = ({ onUpdateDerivedAddress }) => {
+  const program = useAmericanPsyOptionsProgram();
+  const { pushErrorNotification } = useNotifications();
+  const [expiration, setExpiration] = useState(moment.utc().endOf('day'));
+  const [underlyingMint, setUnderlyingMint] = useState<PublicKey | null>(null);
+  const [quoteMint, setQuoteMint] = useState<PublicKey | null>(null);
+  const underlyingDecimals = useDecimalsForMint(underlyingMint ?? '');
+  const quoteDecimals = useDecimalsForMint(quoteMint ?? '');
+  const [optionType, setOptionType] = useState(OptionType.CALL);
+  const [size, setSize] = useState('');
+  const [strike, setStrike] = useState('');
+  const handleSelectedDateChange = (date: Date | null) => {
+    setExpiration(moment.utc(date).endOf('day'));
+  };
+
+  useEffect(() => {
+    if (!program) {
+      return;
+    }
+    if (underlyingMint && quoteMint && size && strike && expiration) {
+      const expirationTimestamp = expiration.unix();
+      const sizeBigNum = new BigNumber(size);
+      const strikeBigNum = new BigNumber(strike);
+      (async () => {
+        try {
+          let optionUnderlyingDecimals = underlyingDecimals;
+          let optionQuoteDecimals = quoteDecimals;
+          let underlyingAmountPerContract = sizeBigNum;
+          let quoteAmountPerContract = strikeBigNum.multipliedBy(sizeBigNum);
+          if (optionType === OptionType.PUT) {
+            optionUnderlyingDecimals = quoteDecimals;
+            optionQuoteDecimals = underlyingDecimals;
+            underlyingAmountPerContract = strikeBigNum.multipliedBy(sizeBigNum);
+            quoteAmountPerContract = sizeBigNum;
+          }
+          const underlyingAmountPerContractBN = new BN(
+            underlyingAmountPerContract
+              .multipliedBy(new BigNumber(10).pow(optionUnderlyingDecimals))
+              .toString(),
+          );
+          const quoteAmountPerContractBN = new BN(
+            quoteAmountPerContract
+              .multipliedBy(new BigNumber(10).pow(optionQuoteDecimals))
+              .toString(),
+          );
+          const [optionKey] = await deriveOptionKeyFromParams({
+            programId: program.programId,
+            underlyingMint,
+            quoteMint,
+            underlyingAmountPerContract: underlyingAmountPerContractBN,
+            quoteAmountPerContract: quoteAmountPerContractBN,
+            expirationUnixTimestamp: new BN(expirationTimestamp),
+          });
+          onUpdateDerivedAddress(optionKey.toString());
+        } catch (err) {
+          pushErrorNotification(err);
+        }
+      })();
+    }
+    // when all inputs are there, derive the option mint address
+  }, [
+    expiration,
+    onUpdateDerivedAddress,
+    optionType,
+    program,
+    pushErrorNotification,
+    quoteDecimals,
+    quoteMint,
+    size,
+    strike,
+    underlyingDecimals,
+    underlyingMint,
+  ]);
+
+  return (
+    <Box borderTop={darkBorder}>
+      <Box mx={2} mt={2}>
+        (Optional) enter the parameters to derive the option address.
+      </Box>
+      <ExpirationInput onChange={handleSelectedDateChange} value={expiration} />
+      <Box display="flex" justifyContent="center">
+        <FormControl component="fieldset">
+          <RadioGroup
+            value={optionType}
+            onChange={(e) => setOptionType(e.target.value as OptionType)}
+            row
+          >
+            <FormControlLabel
+              value={OptionType.CALL}
+              control={<Radio />}
+              label="Call"
+            />
+            <FormControlLabel
+              value={OptionType.PUT}
+              control={<Radio />}
+              label="Put"
+            />
+          </RadioGroup>
+        </FormControl>
+      </Box>
+      <Box display="flex" borderBottom={darkBorder} borderTop={darkBorder}>
+        <Box width="50%" p={2} borderRight={darkBorder}>
+          Underlying Asset:
+          <Box mt={2}>
+            <SelectAssetOrEnterMint
+              mint={underlyingMint}
+              onSelectAsset={setUnderlyingMint}
+            />
+          </Box>
+        </Box>
+        <Box width="50%" p={2}>
+          Quote Asset:
+          <Box mt={2}>
+            <SelectAssetOrEnterMint
+              mint={quoteMint}
+              onSelectAsset={setQuoteMint}
+            />
+          </Box>
+        </Box>
+      </Box>
+      <Box display="flex" borderBottom={darkBorder}>
+        <Box width="50%" p={2} borderRight={darkBorder}>
+          <TextField
+            value={size}
+            label="Contract Size"
+            variant="filled"
+            onChange={(e) => setSize(e.target.value)}
+            helperText={
+              size && Number.isNaN(parseFloat(size)) ? 'Must be a number' : null
+            }
+          />
+        </Box>
+        <Box width="50%" p={2}>
+          <Box pb={2}>
+            <TextField
+              value={strike}
+              label="Strike Price"
+              variant="filled"
+              onChange={(e) => setStrike(e.target.value)}
+              helperText={
+                strike && Number.isNaN(parseFloat(strike))
+                  ? 'Must be a number'
+                  : null
+              }
+            />
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+};

--- a/src/hooks/PsyOptionsAPI/useCheckIfMarketExists.ts
+++ b/src/hooks/PsyOptionsAPI/useCheckIfMarketExists.ts
@@ -25,6 +25,10 @@ export const useCheckIfMarketExists = (): ((obj: {
       underlyingAmountPerContract,
       underlyingAssetMintKey,
     }) => {
+      if (!program) {
+        return null;
+      }
+
       const [optionMarketKey] = await deriveOptionKeyFromParams({
         programId: program.programId,
         underlyingMint: underlyingAssetMintKey,


### PR DESCRIPTION
Maybe it's redundant with the info showing up underneath user input. It's good if the user is just entering the option address, but maybe we should hide it when the address gets automatically updated from the param inputs.

<img width="1904" alt="Screen Shot 2021-10-11 at 10 55 34 PM" src="https://user-images.githubusercontent.com/9965521/136899566-5a376d99-be8a-4aa4-a760-4f3ea2849796.png">
